### PR TITLE
Fix UT on Windows when directories contain some space

### DIFF
--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/build/MavenBuildExecutorTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/build/MavenBuildExecutorTest.java
@@ -124,8 +124,13 @@ public class MavenBuildExecutorTest {
       @Override
       public boolean matches(Object o) {
         Command c = (Command) o;
+        // Windows directory with space use case
+        String quote = "";
+        if (pom.getAbsolutePath().contains(" ")) {
+          quote = "\"";
+        }
         return c.toCommandLine().contains("mvn")
-          && c.toCommandLine().contains("-f " + pom.getAbsolutePath())
+          && c.toCommandLine().contains("-f " + quote + pom.getAbsolutePath())
           && c.toCommandLine().contains("-X")
           && c.toCommandLine().contains(goal);
       }

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/build/SonarScannerExecutorTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/build/SonarScannerExecutorTest.java
@@ -99,8 +99,13 @@ public class SonarScannerExecutorTest {
       @Override
       public boolean matches(Object o) {
         Command c = (Command) o;
+        // Windows directory with space use case
+        String quote = "";
+        if (c.getDirectory().getAbsolutePath().contains(" ")) {
+          quote = "\"";
+        }
         return c.getDirectory().equals(new File("."))
-          && c.toCommandLine().contains("sonar-runner.sh my-task")
+          && c.toCommandLine().contains("sonar-runner.sh" + quote + " my-task")
           && c.toCommandLine().contains("-e")
           && c.toCommandLine().contains("-Dsonar.jdbc.dialect")
           && c.toCommandLine().contains("-Dsonar.projectKey");

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/config/ConfigurationTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/config/ConfigurationTest.java
@@ -23,18 +23,18 @@ import com.google.common.collect.ImmutableMap;
 import com.sonar.orchestrator.PropertyAndEnvTest;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.test.MockHttpServer;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.net.InetAddress;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static com.sonar.orchestrator.TestModules.setEnv;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -133,11 +133,11 @@ public class ConfigurationTest extends PropertyAndEnvTest {
   }
 
   @Test
-  public void getFileLocationOfShared() {
-    URL url= getClass().getResource("/com/sonar/orchestrator/config/ConfigurationTest/sample.properties");
+  public void getFileLocationOfShared() throws URISyntaxException {
+    URL url = getClass().getResource("/com/sonar/orchestrator/config/ConfigurationTest/sample.properties");
     Properties props = new Properties();
     props.setProperty("orchestrator.configUrl", url.toString());
-    props.setProperty("orchestrator.it_sources", FilenameUtils.getFullPath(url.getPath()));
+    props.setProperty("orchestrator.it_sources", FilenameUtils.getFullPath(url.toURI().getPath()));
     Configuration config = Configuration.create(props);
 
     FileLocation location = config.getFileLocationOfShared("sample.properties");
@@ -147,14 +147,14 @@ public class ConfigurationTest extends PropertyAndEnvTest {
   }
 
   @Test
-  public void getFileLocationOfSharedApplyPriority() {
+  public void getFileLocationOfSharedApplyPriority() throws URISyntaxException {
     URL url = getClass().getResource("/com/sonar/orchestrator/config/ConfigurationTest/sample.properties");
     Properties props = new Properties();
     props.setProperty("orchestrator.configUrl", url.toString());
-    Map<String,String> envVariables = new HashMap<>(System.getenv());
-    envVariables.put("SONAR_IT_SOURCES", FilenameUtils.getFullPath(url.getPath()));
+    Map<String, String> envVariables = new HashMap<>(System.getenv());
+    envVariables.put("SONAR_IT_SOURCES", FilenameUtils.getFullPath(url.toURI().getPath()));
     setEnv(ImmutableMap.copyOf(envVariables));
-    props.setProperty("orchestrator.it_sources", FilenameUtils.getFullPath(url.getPath()));
+    props.setProperty("orchestrator.it_sources", FilenameUtils.getFullPath(url.toURI().getPath()));
     Configuration config = Configuration.create(props);
 
     FileLocation location = config.getFileLocationOfShared("sample.properties");
@@ -181,7 +181,7 @@ public class ConfigurationTest extends PropertyAndEnvTest {
     URL url = getClass().getResource("/com/sonar/orchestrator/config/ConfigurationTest/sample.properties");
     Properties props = new Properties();
     props.setProperty("orchestrator.configUrl", url.toString());
-    props.setProperty("orchestrator.it_sources", "/com/sonar/orchestrator/config/ConfigurationTest/sample.properties" );
+    props.setProperty("orchestrator.it_sources", "/com/sonar/orchestrator/config/ConfigurationTest/sample.properties");
     Configuration config = Configuration.create(props);
 
     config.getFileLocationOfShared(".");

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/FileLocationTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/FileLocationTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.sonar.orchestrator.PropertyAndEnvTest;
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,20 +62,20 @@ public class FileLocationTest extends PropertyAndEnvTest {
   }
 
   @Test
-  public void ofShared() {
+  public void ofShared() throws URISyntaxException {
     URL url = getClass().getResource("/com/sonar/orchestrator/locator/FileLocationTest/index.txt");
-    FileLocation location = FileLocation.ofShared("abap/foo.txt", FilenameUtils.getFullPath(url.getPath()));
+    FileLocation location = FileLocation.ofShared("abap/foo.txt", FilenameUtils.getFullPath(url.toURI().getPath()));
     assertThat(location.getFile().isFile()).isTrue();
     assertThat(location.getFile().exists()).isTrue();
     assertThat(location.getFile().getName()).isEqualTo("foo.txt");
   }
 
   @Test
-  public void ofSharedWithEnv() {
+  public void ofSharedWithEnv() throws URISyntaxException {
     URL url = getClass().getResource("/com/sonar/orchestrator/locator/FileLocationTest/index.txt");
 
     Map<String, String> envVariables = new HashMap<>(System.getenv());
-    envVariables.put("SONAR_IT_SOURCES", FilenameUtils.getFullPath(url.getPath()));
+    envVariables.put("SONAR_IT_SOURCES", FilenameUtils.getFullPath(url.toURI().getPath()));
     setEnv(ImmutableMap.copyOf(envVariables));
 
     FileLocation location = FileLocation.ofShared("abap/foo.txt");
@@ -84,9 +85,9 @@ public class FileLocationTest extends PropertyAndEnvTest {
   }
 
   @Test
-  public void ofSharedWithSystemProperty() {
+  public void ofSharedWithSystemProperty() throws URISyntaxException {
     URL url = getClass().getResource("/com/sonar/orchestrator/locator/FileLocationTest/index.txt");
-    System.setProperty("orchestrator.it_sources", FilenameUtils.getFullPath(url.getPath()));
+    System.setProperty("orchestrator.it_sources", FilenameUtils.getFullPath(url.toURI().getPath()));
     FileLocation location = FileLocation.ofShared("abap/foo.txt");
     assertThat(location.getFile().isFile()).isTrue();
     assertThat(location.getFile().exists()).isTrue();


### PR DESCRIPTION
Fix some UT for managing directories containing some space (mainly orchestrator sources location), like :

```
java.lang.IllegalStateException: Please check the system property 'orchestrator.it_sources' or the env variable 'SONAR_IT_SOURCES'. Directory does not exist: C:\Users\Firstname%20Lastname\git\orchestrator\sonar-orchestrator\target\test-classes\com\sonar\orchestrator\locator\FileLocationTest
```