### PR TITLE
Unit tests for proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ export MAVEN_REMOTE_REPOSITORY=http://nexus.internal.sonarsource.com/nexus/conte
 * If running with Oracle as the database, must have jdbc ojdbc14 drive in your maven repository
 * make sure you have firefox available through the command line
 
+# For running orchestrator behind a corporate proxy, add Java properties :
+```
+-Dhttp.proxyHost=proxy.company.com
+-Dhttp.proxyPort=80
+-Dhttps.proxyHost=proxy.company.com
+-Dhttps.proxyPort=80
+-Dhttp.nonProxyHosts="localhost|127.0.0.1|*.company.com"
+-Dhttp.proxyUser=foo
+-Dhttp.proxyPassword=bar
+```
+
 # For running orchestrator with a custom Maven installation, add Java properties :
 ```
 -Dmaven.localRepository="C:/your/maven/repository"

--- a/sonar-orchestrator/pom.xml
+++ b/sonar-orchestrator/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <argLine>-Xmx128m -server</argLine>
+    <okhttp.version>3.4.1</okhttp.version>
   </properties>
 
   <build>
@@ -79,7 +80,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.4.1</version>
+      <version>${okhttp.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -215,7 +216,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>3.0.1</version>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/sonar-orchestrator/pom.xml
+++ b/sonar-orchestrator/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <argLine>-Xmx128m -server</argLine>
-    <okhttp.version>3.4.1</okhttp.version>
+    <okhttp.version>3.5.0</okhttp.version>
   </properties>
 
   <build>

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/URLLocator.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/URLLocator.java
@@ -22,13 +22,17 @@ package com.sonar.orchestrator.locator;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.Route;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -101,9 +105,24 @@ class URLLocator implements Locator<URLLocation> {
   private static Response sendHttpRequest(URLLocation location) throws IOException {
     LOG.info("Downloading: " + location.getURL());
 
-    OkHttpClient httpClient = new OkHttpClient.Builder()
-      .readTimeout(60, TimeUnit.SECONDS)
-      .build();
+    OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS);
+
+    // OkHttp detect 'http.proxyHost' java property, but credentials should be filled
+    final String proxyUser = System.getProperty("http.proxyUser");
+    if (StringUtils.isNotBlank(System.getProperty("http.proxyHost")) && StringUtils.isNotBlank(proxyUser)) {
+      httpClientBuilder.proxyAuthenticator(new Authenticator() {
+        @Override
+        public Request authenticate(Route route, Response response) throws IOException {
+          if (HttpURLConnection.HTTP_PROXY_AUTH == response.code()) {
+            String credential = Credentials.basic(proxyUser, System.getProperty("http.proxyPassword"));
+            return response.request().newBuilder().header("Proxy-Authorization", credential).build();
+          }
+          return null;
+        }
+      });
+    }
+
+    OkHttpClient httpClient = httpClientBuilder.build();
     Request httpRequest = new Request.Builder()
       .url(location.getURL())
       .header("User-Agent", USER_AGENT)


### PR DESCRIPTION
Following #1 (Proxy support : unit tests).

NB: 
* SSL not supported, focus on proxy authentication
* Using Jetty version included in project, not upgraded to last like [sonar-scanner-api:ProxyTest](https://github.com/SonarSource/sonar-scanner-api/blob/master/its/it-tests/src/test/java/com/sonar/scanner/api/it/ProxyTest.java)
* okhttp upgraded to v3.5.0 (required for proxy test, see [#2525](https://github.com/square/okhttp/issues/2525))