### PR TITLE
ORCH-439 - remove usage of deprecated webservice

### DIFF
--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/container/Server.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/container/Server.java
@@ -260,9 +260,9 @@ public class Server {
     newHttpCall("/api/qualityprofiles/add_project")
       .setMethod(HttpMethod.POST)
       .setAdminCredentials()
-      .setParam("projectKey", projectKey)
+      .setParam("project", projectKey)
       .setParam("language", languageKey)
-      .setParam("profileName", profileName)
+      .setParam("qualityProfile", profileName)
       .execute();
   }
 }

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/container/Server.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/container/Server.java
@@ -218,7 +218,7 @@ public class Server {
     newHttpCall("/api/projects/create")
       .setMethod(HttpMethod.POST)
       .setAdminCredentials()
-      .setParam("key", projectKey)
+      .setParam("project", projectKey)
       .setParam("name", projectName)
       .execute();
   }

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/container/ServerTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/container/ServerTest.java
@@ -93,7 +93,7 @@ public class ServerTest {
     RecordedRequest receivedRequest = server.takeRequest();
     assertThat(receivedRequest.getMethod()).isEqualTo("POST");
     assertThat(receivedRequest.getPath()).isEqualTo("/api/projects/create");
-    assertThat(receivedRequest.getBody().readUtf8()).isEqualTo("key=foo&name=Foo");
+    assertThat(receivedRequest.getBody().readUtf8()).isEqualTo("project=foo&name=Foo");
   }
 
   private Server newServerForUrl(String url) {

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/container/ServerTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/container/ServerTest.java
@@ -96,6 +96,19 @@ public class ServerTest {
     assertThat(receivedRequest.getBody().readUtf8()).isEqualTo("project=foo&name=Foo");
   }
 
+  @Test
+  public void associateProjectToQualityProfile_sends_POST_request() throws Exception {
+    server.enqueue(new MockResponse());
+    Server underTest = newServerForUrl(this.server.url("").toString());
+
+    underTest.associateProjectToQualityProfile("foo", "bar", "baz");
+
+    RecordedRequest receivedRequest = server.takeRequest();
+    assertThat(receivedRequest.getMethod()).isEqualTo("POST");
+    assertThat(receivedRequest.getPath()).isEqualTo("/api/qualityprofiles/add_project");
+    assertThat(receivedRequest.getBody().readUtf8()).isEqualTo("project=foo&language=bar&qualityProfile=baz");
+  }
+
   private Server newServerForUrl(String url) {
     return new Server(mock(Locators.class), mock(File.class), Edition.COMMUNITY, Version.create("7.3.0.1000"), HttpUrl.parse(url));
   }


### PR DESCRIPTION
- use "project" param instead of "key" when calling api/projects/create
- in Orchestrator#associateProjectToQualityProfile, when using api/qualityprofiles/add_project : 
   * Parameter "projectKey" has been replaced by "project" 
   * Parameter "profileName" has been replaced by "qualityProfile" 

Jira Ticket: [ORCH-439](https://jira.sonarsource.com/browse/ORCH-439)