### PR TITLE
Install bundled plugins as normal plugins if bundled plugins are not supported

### DIFF
--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/ServerInstaller.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/ServerInstaller.java
@@ -36,6 +36,7 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -91,8 +92,16 @@ public class ServerInstaller {
     if (!distrib.isKeepBundledPlugins()) {
       removeBundledPlugins(homeDir);
     }
-    copyBundledPlugins(distrib.getBundledPluginLocations(), homeDir);
-    copyExternalPlugins(packaging, distrib.getPluginLocations(), homeDir);
+
+    if (packaging.getVersion().isGreaterThanOrEquals(8, 5)) {
+      copyBundledPlugins(distrib.getBundledPluginLocations(), homeDir);
+      copyExternalPlugins(packaging, distrib.getPluginLocations(), homeDir);
+    } else {
+      List<Location> plugins = new ArrayList<>();
+      plugins.addAll(distrib.getBundledPluginLocations());
+      plugins.addAll(distrib.getPluginLocations());
+      copyExternalPlugins(packaging, plugins, homeDir);
+    }
     copyJdbcDriver(homeDir);
     Properties properties = configureProperties(distrib, packaging);
     writePropertiesFile(properties, homeDir);

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/OrchestratorBuilderTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/OrchestratorBuilderTest.java
@@ -80,12 +80,25 @@ public class OrchestratorBuilderTest {
   @Test
   public void add_bundled_plugins() {
     Orchestrator orchestrator = new OrchestratorBuilder(Configuration.create())
-      .setSonarVersion(LTS_ALIAS)
+      .setSonarVersion("DEV")
       .addBundledPlugin(MavenLocation.of("org.sonarsource.xml", "sonar-xml-plugin", "1.5.0.1373"))
       .build();
 
     orchestrator.install();
     File dir = new File(orchestrator.getServer().getHome(), "lib/extensions");
+    assertThat(dir).exists();
+    assertThat(dir.listFiles()).hasSize(1);
+  }
+
+  @Test
+  public void add_bundled_plugins_as_normal_plugin() {
+    Orchestrator orchestrator = new OrchestratorBuilder(Configuration.create())
+      .setSonarVersion(LTS_ALIAS)
+      .addBundledPlugin(MavenLocation.of("org.sonarsource.xml", "sonar-xml-plugin", "1.5.0.1373"))
+      .build();
+
+    orchestrator.install();
+    File dir = new File(orchestrator.getServer().getHome(), "extensions/downloads");
     assertThat(dir).exists();
     assertThat(dir.listFiles()).hasSize(1);
   }


### PR DESCRIPTION
This change will treat bundled plugin locations are "normal" plugin locations when the SQ version being started is pre 8.5.