### PR TITLE
ORCH-477 Log allocated ports to help debugging

### DIFF
--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/db/H2.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/db/H2.java
@@ -22,11 +22,16 @@ package com.sonar.orchestrator.db;
 import java.io.File;
 import java.net.InetAddress;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.sonar.orchestrator.util.NetworkUtils.getNextAvailablePort;
 import static java.lang.String.format;
 
 public final class H2 extends DatabaseClient {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(H2.class);
+
 
   private H2(Builder builder) {
     super(builder);
@@ -63,6 +68,7 @@ public final class H2 extends DatabaseClient {
 
       InetAddress address = InetAddress.getLoopbackAddress();
       int port = getNextAvailablePort(address);
+      LOGGER.info("Port allocated for H2: {}", port);
       setUrl(format("jdbc:h2:tcp://%s:%d/sonar;USER=sonar;PASSWORD=sonar", address.getHostAddress(), port));
     }
 

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/ServerInstaller.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/ServerInstaller.java
@@ -328,6 +328,7 @@ public class ServerInstaller {
     if (webPort == 0) {
       webPort = getNextAvailablePort(webHost);
     }
+    LOG.info("Port allocated for the WebServer: {}", webPort);
     return webPort;
   }
 
@@ -351,10 +352,12 @@ public class ServerInstaller {
   }
 
   private static int loadPort(String portProperty, Properties definedProperties, InetAddress webHost) {
-    return Optional.ofNullable(definedProperties.getProperty(portProperty))
+    Integer port = Optional.ofNullable(definedProperties.getProperty(portProperty))
       .filter(s -> !isEmpty(s))
       .map(Integer::parseInt)
       .orElseGet(() -> getNextAvailablePort(webHost));
+    LOG.info("Port allocated for {}: {}", portProperty, port);
+    return port;
   }
 
   private static void completeJavaOptions(Properties properties, String propertyKey) {


### PR DESCRIPTION
Notes for the reviewer:

- I didn't add any complexity to log whether or not the port comes from config, or is allocated using `getNextAvailablePort()`. We can easily figure out if the port comes from config or not, so these logs are helpful as they are, no need for more logic.
- I didn't test (assert) those logs because we don't have a `LogTester` here or equivalent. To me, just for logs, this is ok. 