### PR TITLE
ORCH-473 Exclude the echo module from the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,5 +15,6 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true  # disabled by default
+      downloadExclusions: "*echo*"
       mavenCentralSync: true   # disabled by default
       slackChannel: team-sonarqube-build


### PR DESCRIPTION
Notes for the reviewer:

- The purpose is to exclude the echo module from the release download artifact. The new option used had been suggested by the RE team in https://sonarsource.atlassian.net/browse/BUILD-3949