### PR TITLE
NOJIRA Update property to exclude the echo module from the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@5.1.1
     with:
       publishToBinaries: true  # disabled by default
-      downloadExclusions: "*echo*"
       mavenCentralSync: true   # disabled by default
+      mavenCentralSyncExclusions: "*echo*"
       slackChannel: team-sonarqube-build


### PR DESCRIPTION
Notes for the reviewer:

- `downloadExclusions` is the property for the already existing action `maven-central`, but it was not a new parameter for the `release` action itself that we are using here
- The RE team added an property to drive this setting from the `release` action directly, in PR https://github.com/SonarSource/gh-action_release/pull/98/files
- Also they released a new version of the release action