### PR TITLE
NOJIRA Fix release action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@5.1.1
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true  # disabled by default
       mavenCentralSync: true   # disabled by default


### PR DESCRIPTION
Finally `v5` was the version of the release action to use, Malena confirmed it to me
