### PR TITLE
ORCH-480 Do not override HOST properties

### DIFF
--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/server/ServerInstallerTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/server/ServerInstallerTest.java
@@ -214,13 +214,15 @@ public class ServerInstallerTest {
   }
 
   @Test
-  public void use_random_search_port_on_loopback_address_if_not_defined_in_new_SQ_DCE_search_node() {
+  public void use_random_search_port_if_not_defined_in_new_SQ_DCE_search_node() {
     prepareResolutionOfPackaging(Edition.DATACENTER, Version.create(VERSION_8_6), SQ_ZIP);
 
     Server server = newInstaller().install(new SonarDistribution()
       .setVersion(VERSION_8_6)
       .setServerProperty("sonar.cluster.enabled", "true")
-      .setServerProperty("sonar.cluster.node.type", "search"));
+      .setServerProperty("sonar.cluster.node.type", "search")
+      .setServerProperty("sonar.cluster.node.search.host", "0.0.0.0")
+      .setServerProperty("sonar.cluster.node.es.host", "0.0.0.0"));
 
     assertThat(server.getSearchPort()).isGreaterThan(1023);
   }


### PR DESCRIPTION
For the reviewer:

- cluster host properties should be set outside of orchestrator, so now we fail if they are not
- there was a weird logic (and badly named) with the `loadPort()` function so I reworked this to make the intention clearer (setting a port if none is given)
- this version had been used in a full sonar-enterprise QA loop on PR https://github.com/SonarSource/sonar-enterprise/pull/9912, including HA tasks