### PR TITLE
ORCH-480 Remove support for old versions of SonarQube

### DIFF
--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/config/LicensesTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/config/LicensesTest.java
@@ -42,17 +42,6 @@ public class LicensesTest {
   public ExpectedException expectedException = ExpectedException.none();
 
   @Test
-  public void getLicense_should_fail_if_version_less_than_7_9() throws Exception {
-    Licenses underTest = newLicenses(true);
-
-    Throwable thrown = catchThrowable(() -> underTest.getLicense(Edition.DEVELOPER, Version.create("7.2.0.10000")));
-    assertThat(thrown).hasMessage("Commercial licenses of SonarQube 7.2.0.10000 are no longer supported").isInstanceOf(IllegalArgumentException.class);
-
-    thrown = catchThrowable(() -> underTest.getLicense(Edition.DEVELOPER, Version.create("6.7")));
-    assertThat(thrown).hasMessage("Commercial licenses of SonarQube 6.7 are no longer supported").isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
   public void download_edition_license_and_remove_header_if_present() {
     Licenses underTest = newLicenses(true);
     github.enqueue(new MockResponse().setBody("-----\nheader\n----\nabcde\n\r\n"));


### PR DESCRIPTION
The goal of this PR is to remove all logic associated to the support of old (unsupported) version of SQ. It was more significant than I thought:

- copying plugin in `preparePlugins()` does not have to care about <8.5 anymore
- `copyExternalPlugins()` was also putting the old license plugin for commercial editions. We don't need this 7.2+
- `sonar.forceAuthentication` and `sonar.forceRedirectOnDefaultAdminCredentials` had special treatment for <8.8 versions in `configureProperties()`, not needed anymore
- the DCE configuration was different before 8.6. I removed the logic around `useNewDCESearchClusterConfiguration()` and refactored it to a simple `isClusterEnabled()` logic

After these changes, quite some tests had to be dropped or refactored. I took the opportunity to update SQ versions used in those tests, just for safety.

This version (4.5.0.1670) ran on a complete SQ QA including all master+nightly QA as well, to make sure all scenarios are covered : https://github.com/SonarSource/sonar-enterprise/pull/9961