### PR TITLE
Add package-info.java for dotnet scanner

### DIFF
--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/build/dotnet/scanner/package-info.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/build/dotnet/scanner/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+@ParametersAreNonnullByDefault
+package com.sonar.orchestrator.build.dotnet.scanner;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+


### PR DESCRIPTION
Sets the `ParametersAreNonnullByDefault` package level annotation.