### PR TITLE
NO-JIRA Update slf4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <commonsExec.version>1.3</commonsExec.version>
     <guava.version>18.0</guava.version>
     <junit.version>4.13.2</junit.version>
-    <slf4j.version>1.7.2</slf4j.version>
+    <slf4j.version>2.0.11</slf4j.version>
     <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
     <sonar.exclusions>
       **/com/sonar/orchestrator/echo/**/*.java,target/generated-sources/**/*


### PR DESCRIPTION
In ec7d93bbbf8c8a3837422b6dae301ce73c13ef1e the version of `logback` was updated from `1.2.x` to `1.3.x`. This leads to logging not working correctly anymore:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
```
The reason seems to be that `slf4j` has to be updated along. Logback `1.3.x` seems to require slf4j `2.x`. I didn't really find an official statement about this in the changelog, but see https://github.com/swagger-api/swagger-codegen/issues/12135#issuecomment-1625513809 and https://logback.qos.ch/download.html stating `The current actively developed version of logback supporting Java EE (java.* namespace) is 1.3.14. It requires SLF4J version 2.0.7 and JDK 8.` 