### PR TITLE
ORCH-487 Add support for downloading artifacts without repox

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Aliases can be used to define the versions of SonarQube and plugins to be instal
 
 The alias `LTS` is no more supported for SonarQube since Orchestrator 3.17. It should be replaced by `LATEST_RELEASE[6.7]`.
 
+Please note that since Orchestrator 4.7, if the default value of `orchestrator.artifactory.url` (https://repox.jfrog.io/repox) is _not_ used, 
+the `DEV` and `DOGFOOD` aliases will not work.
+
 ## Local Cache
 
 The artifacts downloaded from Artifactory (SonarQube, plugins) are copied to the local directory `~/.sonar/orchestrator/cache`.
@@ -103,9 +106,11 @@ The test environment is configured in the file `~/.sonar/orchestrator/orchestrat
     # Default is ~/.m2/repository
     #maven.localRepository=/path/to/maven/repository
 
-    # Instance of Artifactory. Default is SonarSource's instance.
+    # Instance of Artifactory. Default is SonarSource's instance (https://repox.jfrog.io/repox).
     # This property can be replaced by the environment variable ARTIFACTORY_URL.
-    #orchestrator.artifactory.url=https://repox.jfrog.io/repox
+    # To use maven central instead, use https://repo1.maven.org/maven2
+    # To use a custom instance, use your own URL that points to a Maven repository.
+    #orchestrator.artifactory.url=https://repo1.maven.org/maven2
 
 The path to configuration file can be overridden with the system property `orchestrator.configUrl`
 or the environment variable `ORCHESTRATOR_CONFIG_URL`.

--- a/sonar-orchestrator/pom.xml
+++ b/sonar-orchestrator/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <okhttp.version>4.5.0</okhttp.version>
-
+    <jupiter.version>5.9.1</jupiter.version>
     <jacoco.version>0.8.10</jacoco.version>
   </properties>
 
@@ -51,6 +51,11 @@
       <groupId>com.eclipsesource.minimal-json</groupId>
       <artifactId>minimal-json</artifactId>
       <version>0.9.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>2.13.2</version>
     </dependency>
 
     <!-- Apache HTTP Client is kept for deprecated methods Server#getWsClient()
@@ -154,7 +159,12 @@
       <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/config/Configuration.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/config/Configuration.java
@@ -19,7 +19,7 @@
  */
 package com.sonar.orchestrator.config;
 
-import com.sonar.orchestrator.locator.ArtifactoryImpl;
+import com.sonar.orchestrator.locator.ArtifactoryFactory;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.Locators;
 import java.io.File;
@@ -56,7 +56,7 @@ public class Configuration {
   private Configuration(File homeDir, Map<String, String> props) {
     this.props = Collections.unmodifiableMap(new HashMap<>(props));
     this.fileSystem = new FileSystem(homeDir, this);
-    this.locators = new Locators(this.fileSystem, ArtifactoryImpl.create(this));
+    this.locators = new Locators(this.fileSystem, ArtifactoryFactory.createArtifactory(this));
   }
 
   public FileSystem fileSystem() {

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/Artifactory.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/Artifactory.java
@@ -19,13 +19,138 @@
  */
 package com.sonar.orchestrator.locator;
 
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonArray;
+import com.sonar.orchestrator.http.HttpCall;
+import com.sonar.orchestrator.http.HttpClientFactory;
+import com.sonar.orchestrator.http.HttpException;
 import java.io.File;
+import java.io.IOException;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
+import okhttp3.HttpUrl;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public interface Artifactory {
-  boolean downloadToFile(MavenLocation location, File toFile);
+import static com.sonar.orchestrator.util.OrchestratorUtils.isEmpty;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
-  Optional<File> downloadToDir(MavenLocation location, File toDir);
+public abstract class Artifactory {
 
-  Optional<String> resolveVersion(MavenLocation location);
+  private static final Logger LOG = LoggerFactory.getLogger(Artifactory.class);
+
+  protected final File tempDir;
+  protected final String baseUrl;
+  @Nullable
+  protected final String apiKey;
+  @Nullable
+  protected final String accessToken;
+
+  protected Artifactory(File tempDir, String baseUrl, @Nullable String accessToken, @Nullable String apiKey) {
+    this.tempDir = tempDir;
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this.accessToken = accessToken;
+  }
+
+  protected boolean moveFile(File tempFile, File toFile) {
+    try {
+      FileUtils.deleteQuietly(toFile);
+      FileUtils.moveFile(tempFile, toFile);
+      return true;
+    } catch (IOException e) {
+      throw new IllegalStateException("Fail to move file " + toFile, e);
+    }
+  }
+
+  protected Optional<File> downloadToDir(MavenLocation location, File toDir, @Nullable String repository) {
+    HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
+    if (!StringUtils.isEmpty(repository)) {
+      urlBuilder.addPathSegment(repository);
+    }
+    HttpUrl url = urlBuilder.addEncodedPathSegments(StringUtils.replace(location.getGroupId(), ".", "/"))
+      .addPathSegment(location.getArtifactId())
+      .addPathSegment(location.getVersion())
+      .addPathSegment(location.getFilename())
+      .build();
+
+    HttpCall call = newArtifactoryCall(url);
+    try {
+      LOG.info("Downloading {}", url);
+      File toFile = call.downloadToDirectory(toDir);
+      LOG.info("Found {} at {}", location, url);
+      return Optional.of(toFile);
+    } catch (HttpException e) {
+      if (e.getCode() != HTTP_NOT_FOUND && e.getCode() != HTTP_UNAUTHORIZED && e.getCode() != HTTP_FORBIDDEN) {
+        throw new IllegalStateException("Failed to request " + url, e);
+      } else {
+        String errorMessage;
+        try {
+          JsonArray errors = Json.parse(e.getBody()).asObject().get("errors").asArray();
+          errorMessage = StreamSupport.stream(errors.spliterator(), false)
+            .map(item -> item.asObject().get("message").asString())
+            .collect(Collectors.joining(", "));
+        } catch (Exception ignored) {
+          errorMessage = "--- Failed to parse response body -- ";
+        }
+        LOG.warn("Could not download artifact from repository '{}': {} - {}",
+          repository,
+          e.getCode(),
+          errorMessage
+        );
+      }
+    }
+    return Optional.empty();
+  }
+
+  protected HttpCall newArtifactoryCall(HttpUrl url) {
+    HttpCall call = HttpClientFactory.create().newCall(url);
+    if (!isEmpty(accessToken)) {
+      call.setHeader("Authorization", "Bearer " + accessToken);
+    } else if (!isEmpty(apiKey)) {
+      call.setHeader("X-JFrog-Art-Api", apiKey);
+    }
+    return call;
+  }
+
+  /**
+   * Examples:
+   * "LATEST_RELEASE" -> ""
+   * "LATEST_RELEASE[7]" -> "7"
+   * "LATEST_RELEASE[7.1]" -> "7.1"
+   * "LATEST_RELEASE[7.1.2]" -> "7.1.2"
+   */
+  protected static String extractVersionFromAlias(String s) {
+    int start = s.indexOf('[');
+    int end = s.indexOf(']');
+    if (start >= 0 && end > start) {
+      return s.substring(start + 1, end);
+    }
+    return "";
+  }
+
+  protected String getBaseUrl() {
+    return baseUrl;
+  }
+
+  protected String getApiKey() {
+    return apiKey;
+  }
+
+  protected String getAccessToken() {
+    return accessToken;
+  }
+
+  public abstract Optional<String> resolveVersion(MavenLocation location);
+
+  public abstract boolean downloadToFile(MavenLocation location, File toFile);
+
+  public abstract Optional<File> downloadToDir(MavenLocation location, File toDir);
+
 }

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.locator;
+
+import com.sonar.orchestrator.config.Configuration;
+import java.io.File;
+
+import static com.sonar.orchestrator.util.OrchestratorUtils.defaultIfEmpty;
+
+public class ArtifactoryFactory {
+
+  private static final String DEFAULT_ARTIFACTORY_URL = "https://repox.jfrog.io/repox";
+
+  /**
+   * Two types of Artifactory are supported: Maven and Default.
+   *
+   * <p>
+   * Default repox artifactory is used if orchestrator.artifactory.url is empty or specifically set to <a href="https://repox.jfrog.io/repox">repox</a>.
+   * Otherwise, we assume the URL points to a maven repository.
+   * </p>
+   */
+  public static Artifactory createArtifactory(Configuration configuration) {
+    File downloadTempDir = new File(configuration.fileSystem().workspace(), "temp-downloads");
+    String baseUrl = defaultIfEmpty(configuration.getStringByKeys("orchestrator.artifactory.url", "ARTIFACTORY_URL"), DEFAULT_ARTIFACTORY_URL);
+
+    if (baseUrl.startsWith(DEFAULT_ARTIFACTORY_URL)) {
+      String accessToken = configuration.getStringByKeys("orchestrator.artifactory.accessToken", "ARTIFACTORY_ACCESS_TOKEN");
+      String apiKey = configuration.getStringByKeys("orchestrator.artifactory.apiKey", "ARTIFACTORY_API_KEY");
+      return new DefaultArtifactory(downloadTempDir, baseUrl, accessToken, apiKey);
+    } else {
+      return new MavenArtifactory(downloadTempDir, baseUrl);
+    }
+  }
+
+  private ArtifactoryFactory() {
+  }
+
+}

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/MavenArtifactory.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/MavenArtifactory.java
@@ -1,0 +1,64 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.locator;
+
+import com.sonar.orchestrator.util.MavenVersionResolver;
+import java.io.File;
+import java.util.Optional;
+
+public class MavenArtifactory extends Artifactory {
+
+  protected MavenArtifactory(File tempDir, String baseUrl) {
+    super(tempDir, baseUrl, null, null);
+  }
+
+  @Override
+  public Optional<String> resolveVersion(MavenLocation location) {
+    MavenVersionResolver versionResolver = new MavenVersionResolver.Builder()
+      .setBaseUrl(baseUrl)
+      .setGroupId(location.getGroupId())
+      .setArtifactId(location.getArtifactId())
+      .build();
+    versionResolver.loadVersions();
+
+    if (location.getVersion().startsWith("LATEST_RELEASE")) {
+      return versionResolver.getLatestVersion(extractVersionFromAlias(location.getVersion()));
+    } else if (isUnsupportedVersionAlias(location.getVersion())) {
+      throw new IllegalStateException("Unsupported version alias for " + location);
+    } else {
+      return Optional.of(location.getVersion());
+    }
+  }
+
+  @Override
+  public boolean downloadToFile(MavenLocation location, File toFile) {
+    Optional<File> tempFile = super.downloadToDir(location, tempDir, null);
+    return tempFile.filter(file -> super.moveFile(file, toFile)).isPresent();
+  }
+
+  @Override
+  public Optional<File> downloadToDir(MavenLocation location, File toDir) {
+    return super.downloadToDir(location, toDir, null);
+  }
+
+  private static boolean isUnsupportedVersionAlias(String version) {
+    return version.startsWith("DEV") || version.startsWith("DOGFOOD") || version.startsWith("LTS") || version.contains("COMPATIBLE");
+  }
+}

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/MavenRepositoryVersion.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/MavenRepositoryVersion.java
@@ -1,0 +1,82 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.locator;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+
+@JacksonXmlRootElement(localName = "metadata")
+public class MavenRepositoryVersion {
+
+  @JacksonXmlProperty(localName = "groupId")
+  private String groupId;
+  @JacksonXmlProperty(localName = "artifactId")
+  private String artifactId;
+  @JacksonXmlProperty(localName = "versioning")
+  private Versioning versioning;
+
+  public Versioning getVersioning() {
+    return versioning;
+  }
+
+  public void setVersioning(Versioning versioning) {
+    this.versioning = versioning;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public String getArtifactId() {
+    return artifactId;
+  }
+
+  public static class Versioning {
+    @JacksonXmlProperty(localName = "latest")
+    private String latest;
+
+    @JacksonXmlProperty(localName = "release")
+    private String release;
+
+    @JacksonXmlProperty(localName = "versions")
+    private List<String> versions = new ArrayList<>();
+
+    @JacksonXmlProperty(localName = "lastUpdated")
+    private String lastUpdated;
+
+    public List<String> getVersions() {
+      return versions;
+    }
+
+    public void setVersions(List<String> versions) {
+      this.versions = versions;
+    }
+
+    public String getLatest() {
+      return latest;
+    }
+
+    public String getRelease() {
+      return release;
+    }
+  }
+}

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/util/MavenVersionResolver.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/util/MavenVersionResolver.java
@@ -1,0 +1,122 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.util;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.sonar.orchestrator.locator.MavenRepositoryVersion;
+import com.sonar.orchestrator.version.Version;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import okhttp3.HttpUrl;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import static com.sonar.orchestrator.util.OrchestratorUtils.isEmpty;
+
+public class MavenVersionResolver {
+
+  private static final String MAVEN_METADATA_XML = "maven-metadata.xml";
+
+  private final String baseUrl;
+  private final String groupId;
+  private final String artifactId;
+  private List<String> versions;
+
+  public MavenVersionResolver(String baseUrl, String groupId, String artifactId) {
+    this.baseUrl = baseUrl;
+    this.groupId = groupId;
+    this.artifactId = artifactId;
+  }
+
+  public void loadVersions() {
+    try {
+      MavenRepositoryVersion mavenMetadata = downloadVersions();
+      this.versions = mavenMetadata.getVersioning().getVersions();
+      this.versions.sort(Comparator.naturalOrder());
+    } catch (IOException e) {
+      throw new IllegalStateException("Fail to load versions of " + groupId + ":" + artifactId, e);
+    }
+  }
+
+  public Optional<String> getLatestVersion(@Nullable String majorMinorVersion) {
+    if (isEmpty(majorMinorVersion)) {
+      return Optional.of(this.versions.get(versions.size() - 1));
+    }
+
+    List<String> filteredVersions = versions.stream()
+      .filter(version -> version.startsWith(majorMinorVersion))
+      .collect(Collectors.toList());
+
+    if (!filteredVersions.isEmpty()) {
+      return filteredVersions.stream()
+        .map(Version::create)
+        .max(Comparator.naturalOrder())
+        .map(Version::toString);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  public MavenRepositoryVersion downloadVersions() throws IOException {
+    URL url = getUrl();
+    return new XmlMapper().readValue(url, MavenRepositoryVersion.class);
+  }
+
+  @NotNull
+  private URL getUrl() {
+    return HttpUrl.parse(baseUrl).newBuilder()
+      .addEncodedPathSegments(StringUtils.replace(groupId, ".", "/"))
+      .addPathSegment(artifactId)
+      .addPathSegment(MAVEN_METADATA_XML)
+      .build()
+      .url();
+  }
+
+  public static class Builder {
+    String baseUrl;
+    String groupId;
+    String artifactId;
+
+    public Builder setBaseUrl(String baseUrl) {
+      this.baseUrl = baseUrl;
+      return this;
+    }
+
+    public Builder setGroupId(String groupId) {
+      this.groupId = groupId;
+      return this;
+    }
+
+    public Builder setArtifactId(String artifactId) {
+      this.artifactId = artifactId;
+      return this;
+    }
+
+    public MavenVersionResolver build() {
+      return new MavenVersionResolver(baseUrl, groupId, artifactId);
+    }
+  }
+
+}

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/ArtifactoryFactoryTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/ArtifactoryFactoryTest.java
@@ -1,0 +1,119 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.locator;
+
+import com.sonar.orchestrator.config.Configuration;
+import java.util.HashMap;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ArtifactoryFactoryTest {
+
+  private static final String DEFAULT_REPOSITORY = "https://repox.jfrog.io/repox";
+  private static final String SOME_MAVEN_REPOSITORY = "https://localhost:9000/maven-repo";
+  private static final String ACCESS_TOKEN = "access_token";
+  private static final String API_KEY = "api_key";
+
+  @ParameterizedTest
+  @MethodSource("params")
+  void createArtifactory_shouldInstantiateCorrectArtifactory(Parameters parameters) {
+    Artifactory result = ArtifactoryFactory.createArtifactory(getConfiguration(parameters.getInputUrl(), parameters.getInputApiKey(), parameters.getInputAccessToken()));
+
+    Assertions.assertEquals(parameters.getExpectedUrl(), result.getBaseUrl());
+    Assertions.assertEquals(parameters.getExpectedApiKey(), result.getApiKey());
+    Assertions.assertEquals(parameters.getExpectedAccessToken(), result.getAccessToken());
+    assertThat(result).isInstanceOf(parameters.getExpectedClass());
+  }
+
+  private static Configuration getConfiguration(String url, String apiKey, String accessToken) {
+    HashMap<String, String> properties = new HashMap<>();
+    properties.put("orchestrator.artifactory.url", url);
+    properties.put("orchestrator.artifactory.apiKey", apiKey);
+    properties.put("orchestrator.artifactory.accessToken", accessToken);
+    return Configuration.builder()
+      .addProperties(properties)
+      .addEnvVariables()
+      .build();
+  }
+
+  private static Stream<Arguments> params() {
+    return Stream.of(
+      Arguments.of(new Parameters(null, DEFAULT_REPOSITORY, API_KEY, API_KEY, ACCESS_TOKEN, ACCESS_TOKEN, DefaultArtifactory.class)),
+      Arguments.of(new Parameters("", DEFAULT_REPOSITORY, API_KEY, API_KEY, ACCESS_TOKEN, ACCESS_TOKEN, DefaultArtifactory.class)),
+      Arguments.of(new Parameters(DEFAULT_REPOSITORY, DEFAULT_REPOSITORY, API_KEY, API_KEY, ACCESS_TOKEN, ACCESS_TOKEN, DefaultArtifactory.class)),
+      Arguments.of(new Parameters(SOME_MAVEN_REPOSITORY, SOME_MAVEN_REPOSITORY, API_KEY, null, ACCESS_TOKEN, null, MavenArtifactory.class))
+    );
+  }
+
+  static class Parameters {
+    private final String inputUrl;
+    private final String expectedUrl;
+    private final String inputApiKey;
+    private final String expectedApiKey;
+    private final String inputAccessToken;
+    private final String expectedAccessToken;
+    private final Class<?> expectedClass;
+
+    public Parameters(@Nullable String inputUrl, String expectedUrl, String inputApiKey, @Nullable String expectedApiKey, String inputAccessToken,
+      @Nullable String expectedAccessToken, Class<?> expectedClass) {
+      this.inputUrl = inputUrl;
+      this.expectedUrl = expectedUrl;
+      this.inputApiKey = inputApiKey;
+      this.expectedApiKey = expectedApiKey;
+      this.inputAccessToken = inputAccessToken;
+      this.expectedAccessToken = expectedAccessToken;
+      this.expectedClass = expectedClass;
+    }
+
+    public String getInputUrl() {
+      return inputUrl;
+    }
+
+    public String getExpectedUrl() {
+      return expectedUrl;
+    }
+
+    public String getInputApiKey() {
+      return inputApiKey;
+    }
+
+    public String getExpectedApiKey() {
+      return expectedApiKey;
+    }
+
+    public String getInputAccessToken() {
+      return inputAccessToken;
+    }
+
+    public String getExpectedAccessToken() {
+      return expectedAccessToken;
+    }
+
+    public Class<?> getExpectedClass() {
+      return expectedClass;
+    }
+  }
+}

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
@@ -43,7 +43,7 @@ import org.junit.rules.Timeout;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ArtifactoryImplTest {
+public class DefaultArtifactoryTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -66,7 +66,7 @@ public class ArtifactoryImplTest {
     Configuration configuration = newConfiguration()
       .setProperty("orchestrator.artifactory.apiKey", "")
       .build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
 
     File targetFile = temp.newFile();
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
@@ -88,7 +88,7 @@ public class ArtifactoryImplTest {
     Configuration configuration = newConfiguration()
       .setProperty("orchestrator.artifactory.apiKey", "")
       .build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
 
     File targetFile = temp.newFile();
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
@@ -114,7 +114,7 @@ public class ArtifactoryImplTest {
     Configuration configuration = newConfiguration()
       .setProperty("orchestrator.artifactory.apiKey", "abcde")
       .build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
 
     File targetFile = temp.newFile();
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
@@ -135,7 +135,7 @@ public class ArtifactoryImplTest {
             .setProperty("orchestrator.artifactory.accessToken", "abcde")
             .setProperty("orchestrator.artifactory.apiKey", "defgh")
             .build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
 
     File targetFile = temp.newFile();
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
@@ -158,7 +158,7 @@ public class ArtifactoryImplTest {
     Configuration configuration = newConfiguration().build();
 
     File targetFile = temp.newFile();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
     assertThat(found).isFalse();
@@ -172,7 +172,7 @@ public class ArtifactoryImplTest {
     Configuration configuration = newConfiguration().build();
 
     File targetFile = temp.newFile();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
     assertThat(found).isFalse();
@@ -186,7 +186,7 @@ public class ArtifactoryImplTest {
     Configuration configuration = newConfiguration().build();
 
     File targetFile = temp.newFile();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
     assertThat(found).isFalse();
@@ -197,7 +197,7 @@ public class ArtifactoryImplTest {
     prepareResponseError(500);
     Configuration configuration = newConfiguration().build();
     File targetFile = temp.newFile();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
 
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage(new TypeSafeMatcher<String>() {
@@ -218,7 +218,7 @@ public class ArtifactoryImplTest {
   @Test
   public void resolveVersion_returns_version_if_not_an_alias() throws Exception {
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
 
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "7.1.0.1234");
     Optional<String> version = underTest.resolveVersion(location);
@@ -229,7 +229,7 @@ public class ArtifactoryImplTest {
   @Test
   public void resolveVersion_throws_ISE_if_deprecated_LTS_alias() throws Exception {
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LTS");
 
     expectedException.expect(IllegalStateException.class);
@@ -241,7 +241,7 @@ public class ArtifactoryImplTest {
   @Test
   public void resolveVersion_throws_ISE_if_deprecated_OLDEST_COMPATIBLE_alias() throws Exception {
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "OLDEST_COMPATIBLE");
 
     expectedException.expect(IllegalStateException.class);
@@ -255,7 +255,7 @@ public class ArtifactoryImplTest {
     prepareVersions("6.7", "7.0", "7.1", "7.1.1", "6.7.3");
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -269,7 +269,7 @@ public class ArtifactoryImplTest {
     prepareVersions();
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -281,7 +281,7 @@ public class ArtifactoryImplTest {
     prepareVersions("7.1.0.1000", "7.1.1.1500", "7.1.0.1400");
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE[7.1]");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -295,7 +295,7 @@ public class ArtifactoryImplTest {
     prepareVersions("7.1.0.1000", "7.2.1.1500", "7.1.0.1400");
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE[7]");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -309,7 +309,7 @@ public class ArtifactoryImplTest {
     prepareVersions("6.7.0.1000", "7.0.0.1010", "7.1.0.1030", "7.1.0.1020");
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "DEV");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -323,7 +323,7 @@ public class ArtifactoryImplTest {
     prepareVersions("7.1.0.1030", "7.1.0.1020");
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "DEV[7.1]");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -337,7 +337,7 @@ public class ArtifactoryImplTest {
     prepareVersions("8.8.0.9999", "8.8.0.10000");
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "DEV");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -351,7 +351,7 @@ public class ArtifactoryImplTest {
     prepareVersions("8.8.0-M1.9999", "8.8.0-M1.10000");
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "DEV");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -365,7 +365,7 @@ public class ArtifactoryImplTest {
     prepareVersions("6.7.0.1000", "7.0.0.1010", "7.1.0.1030", "7.1.0.1020");
 
     Configuration configuration = newConfiguration().build();
-    ArtifactoryImpl underTest = ArtifactoryImpl.create(configuration);
+    Artifactory underTest = DefaultArtifactory.create(configuration);
     MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "DOGFOOD");
 
     Optional<String> version = underTest.resolveVersion(location);
@@ -381,7 +381,7 @@ public class ArtifactoryImplTest {
       .setProperty("orchestrator.artifactory.apiKey", "abcde")
       .build();
 
-    ArtifactoryImpl.create(configuration).resolveVersion(MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE"));
+    DefaultArtifactory.create(configuration).resolveVersion(MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE"));
 
     RecordedRequest request = server.takeRequest();
     assertThat(request.getHeader("X-JFrog-Art-Api")).isEqualTo("abcde");
@@ -405,7 +405,7 @@ public class ArtifactoryImplTest {
       }
     });
 
-    ArtifactoryImpl.create(configuration).resolveVersion(MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE"));
+    DefaultArtifactory.create(configuration).resolveVersion(MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE"));
   }
 
   private void verifyVersionsRequest(String groupId, String artifactId, String versionLayout, String repositories) throws InterruptedException {

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/MavenArtifactoryTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/MavenArtifactoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.locator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class MavenArtifactoryTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  @Rule
+  public MockWebServer server = new MockWebServer();
+  @Rule
+  public TestRule safeguardTimeout = new DisableOnDebug(Timeout.seconds(60L));
+
+  private static final MavenLocation SONAR_PLUGIN_API = MavenLocation.builder()
+    .setGroupId("org.sonarsource.sonarqube")
+    .setArtifactId("sonar-plugin-api")
+    .setVersion("3.0")
+    .build();
+
+  @Test
+  public void downloadToFile_whenSuccessful() throws Exception {
+    prepareServerResponse("this_is_bytecode");
+
+    Artifactory underTest = getMavenArtifactory();
+
+    File targetFile = temp.newFile();
+    boolean found = underTest.downloadToFile(SONAR_PLUGIN_API, targetFile);
+
+    assertThat(found).isTrue();
+    assertThat(targetFile).exists().hasContent("this_is_bytecode");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getPath()).isEqualTo("/org/sonarsource/sonarqube/sonar-plugin-api/3.0/sonar-plugin-api-3.0.jar");
+    assertThat(request.getHeader("Authorization")).isNull();
+  }
+
+  @Test
+  public void resolveVersion_whenLATESTRELEASE_shouldResolveToHighestAvailableVersion() throws Exception {
+    prepareServerResponse(getContent());
+    Artifactory underTest = getMavenArtifactory();
+    MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "LATEST_RELEASE");
+
+    Optional<String> version = underTest.resolveVersion(location);
+
+    assertThat(version).hasValue("3.0.1.54424");
+  }
+
+  @Test
+  public void resolveVersion_whenInvalidVersion_shouldThrowException() throws Exception {
+    Artifactory underTest = getMavenArtifactory();
+
+    for (String input : new String[] {"DEV", "DOGFOOD", "LTS", "COMPATIBLE"}) {
+      prepareServerResponse(getContent());
+      MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", input);
+      assertThrows(IllegalStateException.class, () -> underTest.resolveVersion(location));
+    }
+  }
+
+  private void prepareServerResponse(String content) {
+    server.enqueue(new MockResponse().setBody(content));
+  }
+
+  private MavenArtifactory getMavenArtifactory() throws IOException {
+    return new MavenArtifactory(temp.newFolder(), server.url("/").toString());
+  }
+
+  private static String getContent() {
+    return "<metadata>" +
+      "<groupId>org.sonarsource.sonarqube</groupId>" +
+      "<artifactId>sonar-plugin-api</artifactId>" +
+      "<versioning>" +
+      "<latest>3.0.1.54424</latest>" +
+      "<release>3.0.1.54424</release>" +
+      "<versions>" +
+      "<version>1.0</version>" +
+      "<version>1.0.1</version>" +
+      "<version>1.1</version>" +
+      "<version>2.0</version>" +
+      "<version>2.0.1</version>" +
+      "<version>3.0</version>" +
+      "<version>3.0.1</version>" +
+      "<version>3.0.1.54424</version>" +
+      "</versions>" +
+      "<lastUpdated>20221018072817</lastUpdated>" +
+      "</versioning>" +
+      "</metadata>";
+  }
+
+}

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/MavenRepositoryVersionTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/MavenRepositoryVersionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.locator;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import java.util.List;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class MavenRepositoryVersionTest {
+
+  @Test
+  public void deserialization_whenXmlCorrect() throws Exception {
+    String xmlInput = createValidXml();
+    MavenRepositoryVersion deserialized = new XmlMapper().readValue(xmlInput, MavenRepositoryVersion.class);
+
+    assertEquals("org.sonarsource.sonarqube", deserialized.getGroupId());
+    assertEquals("sonar-plugin-api", deserialized.getArtifactId());
+    MavenRepositoryVersion.Versioning versioning = deserialized.getVersioning();
+    assertEquals("3.0.1.54424", versioning.getLatest());
+    assertEquals("3.0.1.54424", versioning.getRelease());
+    List<String> versions = versioning.getVersions();
+    assertTrue(versions.contains("1.0"));
+    assertTrue(versions.contains("1.0.1"));
+    assertTrue(versions.contains("1.1"));
+    assertTrue(versions.contains("2.0"));
+    assertTrue(versions.contains("2.0.1"));
+    assertTrue(versions.contains("3.0"));
+    assertTrue(versions.contains("3.0.1"));
+    assertTrue(versions.contains("3.0.1.54424"));
+  }
+
+  @Test
+  public void deserialization_whenXmlCorrectAndNoVersions() {
+    String xmlInput = createInvalidXml();
+    assertThrows(JsonParseException.class, () -> new XmlMapper().readValue(xmlInput, MavenRepositoryVersion.class));
+  }
+  
+  private String createValidXml() {
+    return "<metadata>" +
+        "<groupId>org.sonarsource.sonarqube</groupId>" +
+        "<artifactId>sonar-plugin-api</artifactId>" +
+        "<versioning>" +
+        "<latest>3.0.1.54424</latest>" +
+        "<release>3.0.1.54424</release>" +
+        "<versions>" +
+          "<version>1.0</version>" +
+          "<version>1.0.1</version>" +
+          "<version>1.1</version>" +
+          "<version>2.0</version>" +
+          "<version>2.0.1</version>" +
+          "<version>3.0</version>" +
+          "<version>3.0.1</version>" +
+          "<version>3.0.1.54424</version>" +
+        "</versions>" +
+        "<lastUpdated>20221018072817</lastUpdated>" +
+        "</versioning>" +
+      "</metadata>";
+  }
+
+  private String createInvalidXml() {
+    return "Some random text";
+  }
+
+}

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/util/MavenVersionResolverTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/util/MavenVersionResolverTest.java
@@ -1,0 +1,97 @@
+/*
+ * Orchestrator
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.util;
+
+import com.sonar.orchestrator.locator.MavenRepositoryVersion;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class MavenVersionResolverTest {
+
+  @ParameterizedTest
+  @MethodSource("params")
+  void loadVersions_whenProvidedEmptyString_shouldReturnLatest(String input, String output) throws IOException {
+    MavenVersionResolver versionResolver = spy(new MavenVersionResolver("https://repo1.maven.org/maven2", "org.sonarsource.sonarqube", "sonar-plugin-api"));
+    when(versionResolver.downloadVersions()).thenReturn(getMavenRepositoryVersion());
+    versionResolver.loadVersions();
+
+    Optional<String> version = versionResolver.getLatestVersion(input);
+    Assertions.assertTrue(version.isPresent());
+    Assertions.assertEquals(output, version.get());
+  }
+
+  @Test
+  public void loadVersions_whenBadUrl_shouldThrowException() {
+    MavenVersionResolver versionResolver = spy(new MavenVersionResolver("https://www.iamabadurl.com", "can-never-exist", "period"));
+    assertThrows(IllegalStateException.class, versionResolver::loadVersions);
+  }
+
+  @Test
+  public void builder_shouldSetFields() {
+    MavenVersionResolver.Builder versionResolver = new MavenVersionResolver.Builder()
+      .setBaseUrl("https://repo1.maven.org/maven2")
+      .setGroupId("org.sonarsource.sonarqube")
+      .setArtifactId("sonar-plugin-api");
+
+    Assertions.assertNotNull(versionResolver);
+    Assertions.assertEquals("https://repo1.maven.org/maven2", versionResolver.baseUrl);
+    Assertions.assertEquals("org.sonarsource.sonarqube", versionResolver.groupId);
+    Assertions.assertEquals("sonar-plugin-api", versionResolver.artifactId);
+  }
+
+  MavenRepositoryVersion getMavenRepositoryVersion() {
+    MavenRepositoryVersion mavenRepositoryVersion = new MavenRepositoryVersion();
+    MavenRepositoryVersion.Versioning versioning = new MavenRepositoryVersion.Versioning();
+    List<String> versions = new ArrayList<>();
+    versions.add("1.0");
+    versions.add("2.0");
+    versions.add("2.0.1");
+    versions.add("3.1");
+    versions.add("4.0");
+    versions.add("5.0");
+    versions.add("5.0.1");
+    versions.add("5.0.1.9324");
+    versions.add("6.0");
+    versioning.setVersions(versions);
+    mavenRepositoryVersion.setVersioning(versioning);
+    return mavenRepositoryVersion;
+  }
+
+  private static Stream<Arguments> params() {
+    return Stream.of(
+      Arguments.of("", "6.0"),
+      Arguments.of("2.0", "2.0.1"),
+      Arguments.of("5.0.1", "5.0.1.9324")
+    );
+  }
+
+}


### PR DESCRIPTION
Currently, Orchestrator supports all types of literals to retrieve artifacts, such as

- DEV
- DOGFOOD
- LATEST_RELEASE
- The above three can contain [<version>], i.e. DEV[10.1]
- Hardcoded version i.e. 10.3

With disabling JFrog anonymous usage/authentication, other open source projects that are using Orchestrator can no longer download artifacts from JFrog - unless they specify credentials

The new approach is as follows:

- if `orchestrator.artifactory.url` remains empty, default `https://repox.jfrog.io/repox` is used
- Setting `orchestrator.artifactory.url` to anything else **will be assumed to be a maven repository**

So, for testing, setting `orchestrator.artifactory.url` to `https://repo1.maven.org/maven2`, I tested using a few literals and/or versions (for SQ artifacts):

**1) LATEST_RELEASE[10.0]** - Finds latest in the series

[2024.02.06 09:05:45][c.s.o.l.Artifactory][INFO ] Downloading https://repo1.maven.org/maven2/org/sonarsource/sonarqube/sonar-application/10.0.0.68432/sonar-application-10.0.0.68432.zip
[2024.02.06 09:05:57][c.s.o.l.Artifactory][INFO ] Found [org.sonarsource.sonarqube:sonar-application:10.0.0.68432:zip] at https://repo1.maven.org/maven2/org/sonarsource/sonarqube/sonar-application/10.0.0.68432/sonar-application-10.0.0.68432.zip
[2024.02.06 09:05:57][c.s.o.l.MavenLocator][INFO ] Found [org.sonarsource.sonarqube:sonar-application:10.0.0.68432:zip] at /home/alain.kermis/.sonar/orchestrator/cache/3948b47be5795326d3e945ae84ff1f73/sonar-application-10.0.0.68432.zip

**2) 10.0.0.68432** - Exact build number

[2024.02.06 09:08:40][c.s.o.l.Artifactory][INFO ] Downloading https://repo1.maven.org/maven2/org/sonarsource/sonarqube/sonar-application/10.0.0.68432/sonar-application-10.0.0.68432.zip
[2024.02.06 09:08:53][c.s.o.l.Artifactory][INFO ] Found [org.sonarsource.sonarqube:sonar-application:10.0.0.68432:zip] at https://repo1.maven.org/maven2/org/sonarsource/sonarqube/sonar-application/10.0.0.68432/sonar-application-10.0.0.68432.zip
[2024.02.06 09:08:54][c.s.o.l.MavenLocator][INFO ] Found [org.sonarsource.sonarqube:sonar-application:10.0.0.68432:zip] at /home/alain.kermis/.sonar/orchestrator/cache/3948b47be5795326d3e945ae84ff1f73/sonar-application-10.0.0.68432.zip

**3) DEV | DOGFOOD** - Unsupported

java.lang.IllegalStateException: Unsupported version alias for [org.sonarsource.sonarqube:sonar-application:DEV:zip]
java.lang.IllegalStateException: Unsupported version alias for [org.sonarsource.sonarqube:sonar-application:DOGFOOD:zip]


