### PR TITLE
ORCH-490 Make default artifactory URL check less stringent

### DIFF
--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
@@ -26,7 +26,8 @@ import static com.sonar.orchestrator.util.OrchestratorUtils.defaultIfEmpty;
 
 public class ArtifactoryFactory {
 
-  private static final String DEFAULT_ARTIFACTORY_URL = "https://repox.jfrog.io/repox";
+  private static final String DEFAULT_ARTIFACTORY_PREFIX = "https://repox.jfrog.io";
+  private static final String DEFAULT_ARTIFACTORY_URL = DEFAULT_ARTIFACTORY_PREFIX + "/repox";
 
   /**
    * Two types of Artifactory are supported: Maven and Default.
@@ -40,7 +41,7 @@ public class ArtifactoryFactory {
     File downloadTempDir = new File(configuration.fileSystem().workspace(), "temp-downloads");
     String baseUrl = defaultIfEmpty(configuration.getStringByKeys("orchestrator.artifactory.url", "ARTIFACTORY_URL"), DEFAULT_ARTIFACTORY_URL);
 
-    if (baseUrl.startsWith(DEFAULT_ARTIFACTORY_URL)) {
+    if (baseUrl.startsWith(DEFAULT_ARTIFACTORY_PREFIX)) {
       String accessToken = configuration.getStringByKeys("orchestrator.artifactory.accessToken", "ARTIFACTORY_ACCESS_TOKEN");
       String apiKey = configuration.getStringByKeys("orchestrator.artifactory.apiKey", "ARTIFACTORY_API_KEY");
       return new DefaultArtifactory(downloadTempDir, baseUrl, accessToken, apiKey);


### PR DESCRIPTION
As it turns out, not every team/squad in the company uses the default JFrog URL `https://repox.jfrog.io/repox`, rather they use `https://repox.jfrog.io/atrifactory`. Therefore, as per the logic in the [changes](https://github.com/SonarSource/orchestrator/pull/189) introduced to allow external users to default to a maven repository, the strictness of expecting the default URL to start with `https://repox.jfrog.io/repox` to utilize JFrog is flawed.

Let us make it less stringent. If the URL starts with `https://repox.jfrog.io`, default to Repox, otherwise it will be assumed to be a Maven repository.