### PR TITLE
ORCH-498 Get the correct DEV edition of SonarQube Community Build and Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,13 @@ Aliases can be used to define the versions of SonarQube and plugins to be instal
 
 - `DEV` for the latest official build (in terms of version number, not date)
 - `DEV[x.y]` for the latest official build of a series. For example `DEV[5.2]` may install version `5.2.0.1234`.
-- `DOGFOOD` for the latest build of dogfood branch
-- `DOGFOOD[x.y]` for the latest build of a series in dogfood branch
 - `LATEST_RELEASE` for the latest release (in terms of version number, not date)
 - `LATEST_RELEASE[x.y]` for the latest release of a series, for example `LATEST_RELEASE[5.2]`
 
 The alias `LTS` is no more supported for SonarQube since Orchestrator 3.17. It should be replaced by `LATEST_RELEASE[6.7]`.
 
 Please note that since Orchestrator 4.7, if the default value of `orchestrator.artifactory.url` (https://repox.jfrog.io/repox) is _not_ used, 
-the `DEV` and `DOGFOOD` aliases will not work.
+the `DEV` alias will not work.
 
 ## Local Cache
 

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/DefaultArtifactory.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/DefaultArtifactory.java
@@ -57,7 +57,7 @@ public class DefaultArtifactory extends Artifactory {
 
   @Override
   public Optional<File> downloadToDir(MavenLocation location, File toDir) {
-    for (String repository : asList("sonarsource", "sonarsource-qa", "sonarsource-dogfood-builds")) {
+    for (String repository : asList("sonarsource", "sonarsource-qa")) {
       Optional<File> optionalFile = super.downloadToDir(location, toDir, repository);
       if (optionalFile.isPresent()) {
         return optionalFile;
@@ -75,8 +75,6 @@ public class DefaultArtifactory extends Artifactory {
     } else if (location.getVersion().startsWith("DEV")) {
       // only the artifacts that have been promoted (master + release branches)
       repositories = "sonarsource-builds";
-    } else if (location.getVersion().startsWith("DOGFOOD")) {
-      repositories = "sonarsource-dogfood-builds";
     } else if (location.getVersion().startsWith("LTS") || location.getVersion().contains("COMPATIBLE")) {
       throw new IllegalStateException("Unsupported version alias for " + location);
     } else {

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/MavenArtifactory.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/MavenArtifactory.java
@@ -59,6 +59,6 @@ public class MavenArtifactory extends Artifactory {
   }
 
   private static boolean isUnsupportedVersionAlias(String version) {
-    return version.startsWith("DEV") || version.startsWith("DOGFOOD") || version.startsWith("LTS") || version.contains("COMPATIBLE");
+    return version.startsWith("DEV") || version.startsWith("LTS") || version.contains("COMPATIBLE");
   }
 }

--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/PackagingResolver.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/PackagingResolver.java
@@ -73,7 +73,7 @@ public class PackagingResolver {
     }
 
     String version = versionOrAlias.get();
-    if (version.startsWith("DEV") || version.startsWith("LATEST_RELEASE") || version.startsWith("DOGFOOD")) {
+    if (version.startsWith("DEV") || version.startsWith("LATEST_RELEASE")) {
       MavenCoordinates mavenCoordinates = getMavenCoordinates(sonarDistribution, getVersionInBrackets(version));
       MavenLocation location = newMavenLocationOfZip(mavenCoordinates.groupId, mavenCoordinates.artifactId, version);
       Optional<String> resolvedVersion = locators.maven().resolveVersion(location);

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
@@ -361,20 +361,6 @@ public class DefaultArtifactoryTest {
   }
 
   @Test
-  public void resolveVersion_resolves_DOGFOOD_alias() throws Exception {
-    prepareVersions("6.7.0.1000", "7.0.0.1010", "7.1.0.1030", "7.1.0.1020");
-
-    Configuration configuration = newConfiguration().build();
-    Artifactory underTest = DefaultArtifactory.create(configuration);
-    MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", "DOGFOOD");
-
-    Optional<String> version = underTest.resolveVersion(location);
-    assertThat(version).hasValue("7.1.0.1030");
-
-    verifyVersionsRequest(location.getGroupId(), location.getArtifactId(), "*", "sonarsource-dogfood-builds");
-  }
-
-  @Test
   public void resolveVersion_sends_access_token_if_defined() throws Exception {
     prepareVersions("7.1", "7.2");
     Configuration configuration = newConfiguration()

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/MavenArtifactoryTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/MavenArtifactoryTest.java
@@ -85,7 +85,7 @@ public class MavenArtifactoryTest {
   public void resolveVersion_whenInvalidVersion_shouldThrowException() throws Exception {
     Artifactory underTest = getMavenArtifactory();
 
-    for (String input : new String[] {"DEV", "DOGFOOD", "LTS", "COMPATIBLE"}) {
+    for (String input : new String[] {"DEV", "LTS", "COMPATIBLE"}) {
       prepareServerResponse(getContent());
       MavenLocation location = MavenLocation.of("org.sonarsource.sonarqube", "sonar-plugin-api", input);
       assertThrows(IllegalStateException.class, () -> underTest.resolveVersion(location));

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/server/PackagingResolverTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/server/PackagingResolverTest.java
@@ -24,6 +24,7 @@ import com.sonar.orchestrator.container.SonarDistribution;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.Locators;
 import com.sonar.orchestrator.locator.MavenLocation;
+import com.sonar.orchestrator.version.Version;
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
@@ -167,6 +168,12 @@ public class PackagingResolverTest {
     SonarDistribution distribution = new SonarDistribution().setVersion(versionOrAlias).setEdition(edition);
     // developer edition does not exist before 7.2, so the public group id must be used to resolve version alias
     prepareResolutionOfVersion("org.sonarsource.sonarqube", "sonar-application", versionOrAlias, Optional.of(returnedVersion));
+    if (Version.create(returnedVersion).isGreaterThanOrEquals(7, 2)) {
+      prepareResolutionOfVersion("com.sonarsource.sonarqube", "sonarqube-developer", versionOrAlias, Optional.of(returnedVersion));
+      prepareResolutionOfVersion("com.sonarsource.sonarqube", "sonarqube-enterprise", versionOrAlias, Optional.of(returnedVersion));
+      prepareResolutionOfVersion("com.sonarsource.sonarqube", "sonarqube-datacenter", versionOrAlias, Optional.of(returnedVersion));
+    }
+
     File zip = prepareResolutionOfZip(editionGroupId, editionArtifactId, returnedVersion);
 
     Packaging packaging = underTest.resolve(distribution);

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/server/PackagingResolverTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/server/PackagingResolverTest.java
@@ -84,11 +84,11 @@ public class PackagingResolverTest {
 
   @Test
   public void fail_if_version_alias_cant_be_resolved() {
-    SonarDistribution distribution = new SonarDistribution().setVersion("DOGFOOD");
-    prepareResolutionOfVersion("org.sonarsource.sonarqube", "sonar-application", "DOGFOOD", Optional.empty());
+    SonarDistribution distribution = new SonarDistribution().setVersion("DEV");
+    prepareResolutionOfVersion("org.sonarsource.sonarqube", "sonar-application", "DEV", Optional.empty());
 
     expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage("Version can not be resolved: [org.sonarsource.sonarqube:sonar-application:DOGFOOD:zip]");
+    expectedException.expectMessage("Version can not be resolved: [org.sonarsource.sonarqube:sonar-application:DEV:zip]");
 
     underTest.resolve(distribution);
   }


### PR DESCRIPTION
With this logic in place calculation of the Maven Group ID and Artifact ID is dependent on the Edition being passed.
In the past everything was hardcoded to `org.sonarsource.sonarqube:sonar-application`.

With this new logic when passing DEV and DEVELOPER edition the downloaded version is:
![image](https://github.com/user-attachments/assets/c4df877e-b856-4852-b3e2-6fd0d9ad5f53)


When passing DEV and Community edition the downloaded version is:
![image](https://github.com/user-attachments/assets/291e2c00-64e5-40da-9c1c-b3808b4f766e)
 