### PR TITLE
ORCH-523 Add missing modelVersion to the maven repo version object

### DIFF
--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/MavenRepositoryVersion.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/locator/MavenRepositoryVersion.java
@@ -27,6 +27,8 @@ import java.util.List;
 @JacksonXmlRootElement(localName = "metadata")
 public class MavenRepositoryVersion {
 
+  @JacksonXmlProperty(localName = "modelVersion", isAttribute = true)
+  private String modelVersion;
   @JacksonXmlProperty(localName = "groupId")
   private String groupId;
   @JacksonXmlProperty(localName = "artifactId")
@@ -40,6 +42,10 @@ public class MavenRepositoryVersion {
 
   public void setVersioning(Versioning versioning) {
     this.versioning = versioning;
+  }
+  
+  public String getModelVersion() {
+    return modelVersion;
   }
 
   public String getGroupId() {

--- a/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/MavenRepositoryVersionTest.java
+++ b/sonar-orchestrator/src/test/java/com/sonar/orchestrator/locator/MavenRepositoryVersionTest.java
@@ -35,6 +35,7 @@ public class MavenRepositoryVersionTest {
     String xmlInput = createValidXml();
     MavenRepositoryVersion deserialized = new XmlMapper().readValue(xmlInput, MavenRepositoryVersion.class);
 
+    assertEquals("1.1.0", deserialized.getModelVersion());
     assertEquals("org.sonarsource.sonarqube", deserialized.getGroupId());
     assertEquals("sonar-plugin-api", deserialized.getArtifactId());
     MavenRepositoryVersion.Versioning versioning = deserialized.getVersioning();
@@ -58,7 +59,7 @@ public class MavenRepositoryVersionTest {
   }
   
   private String createValidXml() {
-    return "<metadata>" +
+    return "<metadata modelVersion=\"1.1.0\">" +
         "<groupId>org.sonarsource.sonarqube</groupId>" +
         "<artifactId>sonar-plugin-api</artifactId>" +
         "<versioning>" +


### PR DESCRIPTION
Hello,
I am using orchestrator in the integration tests of the [spotbugs/sonar-findbugs](https://github.com/spotbugs/sonar-findbugs) project.
In the recent builds it looks like orchestrator is now failing to parse the content of https://repo1.maven.org/maven2/org/sonarsource/sonarqube/sonar-application/maven-metadata.xml
The error is:
```
java.lang.ExceptionInInitializerError
	at org.sonar.plugins.findbugs.it.FindSecBugsIT.<clinit>(FindSecBugsIT.java:23)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.IllegalStateException: Fail to load versions of org.sonarsource.sonarqube:sonar-application
	at com.sonar.orchestrator.util.MavenVersionResolver.loadVersions(MavenVersionResolver.java:62)
	at com.sonar.orchestrator.locator.MavenArtifactory.resolveVersion(MavenArtifactory.java:39)
	at com.sonar.orchestrator.locator.MavenLocator.resolveVersion(MavenLocator.java:103)
	at com.sonar.orchestrator.server.PackagingResolver.resolveVersion(PackagingResolver.java:79)
	at com.sonar.orchestrator.server.PackagingResolver.resolve(PackagingResolver.java:57)
	at com.sonar.orchestrator.Orchestrator.install(Orchestrator.java:96)
	at com.sonar.orchestrator.Orchestrator.start(Orchestrator.java:118)
	at org.sonar.plugins.findbugs.it.FindbugsTestSuite.<clinit>(FindbugsTestSuite.java:68)
	... 6 more
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "modelVersion" (class com.sonar.orchestrator.locator.MavenRepositoryVersion), not marked as ignorable (3 known properties: "groupId", "artifactId", "versioning"])
 at [Source: (URL); line: 2, column: 32] (through reference chain: com.sonar.orchestrator.locator.MavenRepositoryVersion["modelVersion"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:1127)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:1989)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1700)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1678)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:319)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:176)
	at com.fasterxml.jackson.dataformat.xml.deser.XmlDeserializationContext.readRootValue(XmlDeserializationContext.java:91)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4674)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3560)
	at com.sonar.orchestrator.util.MavenVersionResolver.downloadVersions(MavenVersionResolver.java:87)
	at com.sonar.orchestrator.util.MavenVersionResolver.loadVersions(MavenVersionResolver.java:55)
	... 13 more
```

Adding the missing `modelVersion` field solves the problem on a local build