### PR TITLE
DO_NOT_MERGE_fix_AZmJX1o2U8CNVV2bgk98

### DIFF
--- a/sonar-orchestrator-utils/src/main/java/com/sonar/orchestrator/util/command/CommandExecutor.java
+++ b/sonar-orchestrator-utils/src/main/java/com/sonar/orchestrator/util/command/CommandExecutor.java
@@ -25,6 +25,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -166,7 +167,7 @@ public class CommandExecutor {
   private static class StreamGobbler extends Thread {
     private final InputStream is;
     private final StreamConsumer consumer;
-    private volatile Exception exception;
+    private final AtomicReference<Exception> exception = new AtomicReference<>();
 
     StreamGobbler(InputStream is, StreamConsumer consumer) {
       super("ProcessStreamGobbler");
@@ -183,22 +184,22 @@ public class CommandExecutor {
           consumeLine(line);
         }
       } catch (IOException ioe) {
-        exception = ioe;
+        exception.set(ioe);
       }
     }
 
     private void consumeLine(String line) {
-      if (exception == null) {
+      if (exception.get() == null) {
         try {
           consumer.consumeLine(line);
         } catch (Exception e) {
-          exception = e;
+          exception.set(e);
         }
       }
     }
 
     public Exception getException() {
-      return exception;
+      return exception.get();
     }
   }
 


### PR DESCRIPTION
<strong>java:S3077</strong> - Use a thread-safe type; adding "volatile" is not enough to make this field thread-safe. • <strong>MINOR</strong> • <a href="https://sonarcloud.io/project/issues?id=org.sonarsource.orchestrator:orchestrator-parent&issues=AZmJX1o2U8CNVV2bgk98&open=AZmJX1o2U8CNVV2bgk98">View issue</a>