### PR TITLE
DO NOT MERGE: fix_AZl2kNRnTJNPgjOVPf4F_java:S3457

### DIFF
--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/ServerInstaller.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/ServerInstaller.java
@@ -145,7 +145,7 @@ public class ServerInstaller {
     if (bundledPluginNamePrefixesToKeep.isEmpty()) {
       LOG.info("Remove bundled plugins");
     } else {
-      LOG.info("Remove bundled plugins except: " + String.join(", ", bundledPluginNamePrefixesToKeep));
+      LOG.info("Remove bundled plugins except: {}", String.join(", ", bundledPluginNamePrefixesToKeep));
 
     }
     cleanDirectory(new File(homeDir, "lib/bundled-plugins"), bundledPluginNamePrefixesToKeep);


### PR DESCRIPTION
**Rule:** `java:S3457`
**Severity:** MAJOR
**Issue description:** `Format specifiers should be used instead of string concatenation.`


Replaced string concatenation with SLF4J format specifier {} in LOG.info call