### PR TITLE
DO NOT MERGE: fix_AZnrNg4uQgHvdlpusoNW_java:S1192

### DIFF
--- a/sonar-orchestrator-http/src/main/java/com/sonar/orchestrator/http/HttpCall.java
+++ b/sonar-orchestrator-http/src/main/java/com/sonar/orchestrator/http/HttpCall.java
@@ -50,6 +50,7 @@ public class HttpCall {
   private static final String ADMIN_PASSWORD = "admin";
 
   private static final String DEFAULT_USER_AGENT = "Orchestrator";
+  private static final String CAN_NOT_CALL_FORMAT = "Can not call %s";
 
   private final OkHttpClient okClient;
   private final HttpUrl baseUrl;
@@ -196,10 +197,10 @@ public class HttpCall {
       try {
         doDownloadToFile(okRequest, file);
       } catch (IOException e2) {
-        throw new IllegalStateException(format("Can not call %s", okRequest.url()), e2);
+        throw new IllegalStateException(format(CAN_NOT_CALL_FORMAT, okRequest.url()), e2);
       }
     } catch (IOException e) {
-      throw new IllegalStateException(format("Can not call %s", okRequest.url()), e);
+      throw new IllegalStateException(format(CAN_NOT_CALL_FORMAT, okRequest.url()), e);
     }
   }
 
@@ -221,10 +222,10 @@ public class HttpCall {
       try {
         return doDownloadToDirectory(dir, okRequest);
       } catch (IOException e2) {
-        throw new IllegalStateException(format("Can not call %s", okRequest.url()), e2);
+        throw new IllegalStateException(format(CAN_NOT_CALL_FORMAT, okRequest.url()), e2);
       }
     } catch (IOException e) {
-      throw new IllegalStateException(format("Can not call %s", okRequest.url()), e);
+      throw new IllegalStateException(format(CAN_NOT_CALL_FORMAT, okRequest.url()), e);
     }
   }
 


### PR DESCRIPTION
**Rule:** `java:S1192`
**Severity:** CRITICAL
**Issue description:** `Define a constant instead of duplicating this literal "Can not call %s" 4 times.`


Extracted duplicated string literal "Can not call %s" into constant CAN_NOT_CALL_FORMAT