### PR TITLE
NO-JIRA [DO NOT MERGE] [CLAUDE-STATIC] fix_AZl2kNRnTJNPgjOVPf4F

### DIFF
--- a/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/ServerInstaller.java
+++ b/sonar-orchestrator/src/main/java/com/sonar/orchestrator/server/ServerInstaller.java
@@ -145,7 +145,7 @@ public class ServerInstaller {
     if (bundledPluginNamePrefixesToKeep.isEmpty()) {
       LOG.info("Remove bundled plugins");
     } else {
-      LOG.info("Remove bundled plugins except: " + String.join(", ", bundledPluginNamePrefixesToKeep));
+      LOG.info("Remove bundled plugins except: {}", String.join(", ", bundledPluginNamePrefixesToKeep));
 
     }
     cleanDirectory(new File(homeDir, "lib/bundled-plugins"), bundledPluginNamePrefixesToKeep);


### PR DESCRIPTION
## SonarQube Issue Fix

**Rule:** java:S3457 (MAJOR)
**Message:** Format specifiers should be used instead of string concatenation.

[View issue in SonarCloud](https://sonarcloud.io/project/issues?id=org.sonarsource.orchestrator:orchestrator-parent&issues=AZl2kNRnTJNPgjOVPf4F&open=AZl2kNRnTJNPgjOVPf4F)