### PR TITLE
BUILD-10860: Adopt SonarSource Renovate base config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "github>SonarSource/renovate-config",
     ":preserveSemverRanges"
   ],
   "branchConcurrentLimit": 0,


### PR DESCRIPTION
## Summary

Replace `config:base` with the org-wide Renovate base config (`github>SonarSource/renovate-config`) to inherit supply chain protections:

- `minimumReleaseAge: "5 days"` — delays dependency updates until packages have been published for at least 5 days
- `minimumReleaseAgeBehaviour: "timestamp-optional"` — avoids blocking deps from registries without release timestamps
- `prCreation: "not-pending"` — only creates PRs once the release age requirement is satisfied
- Dependency dashboard visibility
- Shared host rules for Repox/Artifactory access

The base config extends `config:recommended` (successor to `config:base`). All existing repo-specific settings (rate limits, packageRules, `:preserveSemverRanges`) are preserved as local overrides.

## Context

Part of [BUILD-10860](https://sonarsource.atlassian.net/browse/BUILD-10860) — enforcing `minimumReleaseAge` across the org in response to a supply chain incident.

[BUILD-10860]: https://sonarsource.atlassian.net/browse/BUILD-10860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ