### PR TITLE
SONAR-27393 Use major version tags for SonarSource GitHub Actions

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -16,7 +16,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/jira user | JIRA_USER;

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -15,7 +15,7 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -18,7 +18,7 @@ jobs:
             || github.event.review.state == 'approved')
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@545e7cfbb5528e7009a1edcc83e073898d292627 # v3.2.0
+        uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/jira user | JIRA_USER;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
-      - uses: SonarSource/ci-github-actions/build-maven@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
+      - uses: SonarSource/ci-github-actions/get-build-number@v1
+      - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           deploy-pull-request: ${{ github.event_name != 'workflow_call' }}
           artifactory-reader-role: private-reader
@@ -49,7 +49,7 @@ jobs:
         with:
           cache_save: false
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
-      - uses: SonarSource/ci-github-actions/promote@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
+      - uses: SonarSource/ci-github-actions/get-build-number@v1
+      - uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@b9284ef49674428c976147100b9072f74427fbc7 # v6.3.0
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       publishToBinaries: true  # disabled by default
       mavenCentralSync: true   # disabled by default

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Send Slack Notification
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        uses: SonarSource/gh-action_slack-notify@9532fdcfa4143ed5da2da7b0e77172abbe24ae33 # v1.0.2
+        uses: SonarSource/gh-action_slack-notify@v1
         with:
           slackChannel: squad-sq-platform-build-notification

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/build-maven@4ef2061ff3c9dc144a66f8a6e480d04d2d79e3bb # v1.3.25
+      - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           artifactory-reader-role: private-reader
           artifactory-deployer-role: qa-deployer


### PR DESCRIPTION
Replace SHA pins with major version tags so CI always resolves to the latest patch release.

- `ci-github-actions/build-maven` → `@v1`
- `ci-github-actions/get-build-number` → `@v1`
- `ci-github-actions/promote` → `@v1`
- `gh-action_release/.github/workflows/main.yaml` → `@v6`
- `gh-action_slack-notify` → `@v1`
- `vault-action-wrapper` → `@v3`