### PR TITLE
ORCH-558 Use major version tags for SonarSource GitHub Actions

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -21,7 +21,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/PullRequestClosed@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user:  ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -21,7 +21,7 @@ jobs:
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/RequestReview@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/RequestReview@v2
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
           jira-user:    ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -23,7 +23,7 @@ jobs:
           secrets: |
             development/kv/data/jira user | JIRA_USER;
             development/kv/data/jira token | JIRA_TOKEN;
-      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@02f0a8d3280a05b9d2c5ee3b8407cec1b0158ce6 # v2
+      - uses: sonarsource/gh-action-lt-backlog/SubmitReview@v2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           jira-user: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}


### PR DESCRIPTION
## Summary
Replace SHA-pinned SonarSource GitHub Actions with major version tags.

SHA pinning causes the Request Review workflow to fail when the action is updated.

## Changes
- `sonarsource/gh-action-lt-backlog` `02f0a8d3...` → `@v2`