### PR TITLE
ORCH-541 Make MavenLocator safe for concurrent multi-JVM use

### DIFF
--- a/sonar-orchestrator-config/src/main/java/com/sonar/orchestrator/config/FileSystem.java
+++ b/sonar-orchestrator-config/src/main/java/com/sonar/orchestrator/config/FileSystem.java
@@ -88,6 +88,10 @@ public class FileSystem {
     return orchestratorHome.resolve("cache");
   }
 
+  public Path getTempDir() {
+    return orchestratorHome.resolve("_tmp");
+  }
+
   public Path getSonarQubeZipsDir() {
     return sonarQubeZipsDir;
   }

--- a/sonar-orchestrator-config/src/test/java/com/sonar/orchestrator/config/FileSystemTest.java
+++ b/sonar-orchestrator-config/src/test/java/com/sonar/orchestrator/config/FileSystemTest.java
@@ -45,6 +45,7 @@ class FileSystemTest {
     verifySameDirs(underTest.workspace(), Path.of("target"));
     verifySameDirs(underTest.getOrchestratorHome(), homeDir);
     verifySameDirs(underTest.getCacheDir(), homeDir.resolve("cache"));
+    verifySameDirs(underTest.getTempDir(), homeDir.resolve("_tmp"));
     verifySameDirs(underTest.getSonarQubeZipsDir(), homeDir.resolve("zips"));
   }
 

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/Artifactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/Artifactory.java
@@ -26,12 +26,14 @@ import com.sonar.orchestrator.http.HttpClientFactory;
 import com.sonar.orchestrator.http.HttpException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import okhttp3.HttpUrl;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,27 +77,52 @@ public abstract class Artifactory {
     return "";
   }
 
-  protected boolean moveFile(File tempFile, File toFile) {
+  /**
+   * Atomically move {@code source} into {@code target}, tolerating a concurrent winner.
+   * <p>
+   * Readers (see {@link MavenLocator#locateResolvedVersion}) list the cache directory and return its single
+   * file: an atomic rename guarantees the cached file appears fully written or not at all.
+   */
+  protected void moveFile(Path source, Path target) {
     try {
-      FileUtils.deleteQuietly(toFile);
-      FileUtils.moveFile(tempFile, toFile);
+      Files.createDirectories(target.getParent());
+      Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+    } catch (IOException e1) {
+      if (Files.isRegularFile(target)) {
+        LOG.debug("File {} was cached concurrently; discarding our copy {}", target, source);
+        return;
+      }
+      LOG.warn("Atomic move from {} to {} failed: {}", source, target, e1.getMessage());
+      LOG.warn("Falling back to a non-atomic move");
+      try {
+        Files.move(source, target);
+      } catch (IOException e2) {
+        throw new IllegalStateException("Fail to move file " + target, e2);
+      }
+    }
+  }
+
+  /**
+   * Download {@code location} from {@code repository} into {@code destination}. The destination filename is
+   * controlled by the caller (not derived from HTTP {@code Content-Disposition}), so callers can supply a
+   * unique temp file path safe to use from multiple JVMs.
+   */
+  protected boolean downloadFromRepository(MavenLocation location, Path destination, @Nullable String repository) {
+    HttpUrl url = buildArtifactUrl(location, repository);
+    HttpCall call = newArtifactoryCall(url);
+    try {
+      LOG.info("Downloading {}", url);
+      call.downloadToFile(destination.toFile());
+      LOG.info("Found {} at {}", location, url);
       return true;
-    } catch (IOException e) {
-      throw new IllegalStateException("Fail to move file " + toFile, e);
+    } catch (HttpException e) {
+      handleDownloadFailure(e, url, repository);
+      return false;
     }
   }
 
   protected Optional<File> downloadToDir(MavenLocation location, File toDir, @Nullable String repository) {
-    HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
-    if (!isEmpty(repository)) {
-      urlBuilder.addPathSegment(repository);
-    }
-    HttpUrl url = urlBuilder.addEncodedPathSegments(Strings.CS.replace(location.getGroupId(), ".", "/"))
-      .addPathSegment(location.getArtifactId())
-      .addPathSegment(location.getVersion())
-      .addPathSegment(location.getFilename())
-      .build();
-
+    HttpUrl url = buildArtifactUrl(location, repository);
     HttpCall call = newArtifactoryCall(url);
     try {
       LOG.info("Downloading {}", url);
@@ -103,25 +130,40 @@ public abstract class Artifactory {
       LOG.info("Found {} at {}", location, url);
       return Optional.of(toFile);
     } catch (HttpException e) {
-      if (e.getCode() != HTTP_NOT_FOUND && e.getCode() != HTTP_UNAUTHORIZED && e.getCode() != HTTP_FORBIDDEN) {
-        throw new IllegalStateException("Failed to request " + url, e);
-      } else {
-        String errorMessage;
-        try {
-          JsonArray errors = Json.parse(e.getBody()).asObject().get("errors").asArray();
-          errorMessage = StreamSupport.stream(errors.spliterator(), false)
-            .map(item -> item.asObject().get("message").asString())
-            .collect(Collectors.joining(", "));
-        } catch (Exception ignored) {
-          errorMessage = "--- Failed to parse response body -- ";
-        }
-        LOG.warn("Could not download artifact from repository '{}': {} - {}",
-          repository,
-          e.getCode(),
-          errorMessage);
-      }
+      handleDownloadFailure(e, url, repository);
+      return Optional.empty();
     }
-    return Optional.empty();
+  }
+
+  private HttpUrl buildArtifactUrl(MavenLocation location, @Nullable String repository) {
+    HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
+    if (!isEmpty(repository)) {
+      urlBuilder.addPathSegment(repository);
+    }
+    return urlBuilder.addEncodedPathSegments(Strings.CS.replace(location.getGroupId(), ".", "/"))
+      .addPathSegment(location.getArtifactId())
+      .addPathSegment(location.getVersion())
+      .addPathSegment(location.getFilename())
+      .build();
+  }
+
+  private static void handleDownloadFailure(HttpException e, HttpUrl url, @Nullable String repository) {
+    if (e.getCode() != HTTP_NOT_FOUND && e.getCode() != HTTP_UNAUTHORIZED && e.getCode() != HTTP_FORBIDDEN) {
+      throw new IllegalStateException("Failed to request " + url, e);
+    }
+    String errorMessage;
+    try {
+      JsonArray errors = Json.parse(e.getBody()).asObject().get("errors").asArray();
+      errorMessage = StreamSupport.stream(errors.spliterator(), false)
+        .map(item -> item.asObject().get("message").asString())
+        .collect(Collectors.joining(", "));
+    } catch (Exception ignored) {
+      errorMessage = "--- Failed to parse response body -- ";
+    }
+    LOG.warn("Could not download artifact from repository '{}': {} - {}",
+      repository,
+      e.getCode(),
+      errorMessage);
   }
 
   protected HttpCall newArtifactoryCall(HttpUrl url) {
@@ -148,7 +190,40 @@ public abstract class Artifactory {
 
   public abstract Optional<String> resolveVersion(MavenLocation location);
 
-  public abstract boolean downloadToFile(MavenLocation location, File toFile);
+  /**
+   * Download {@code location} into {@code toFile}, atomically and safely from multiple JVMs.
+   * <p>
+   * Each call downloads into a unique temp file under {@link #tempDir} and, on success, atomically moves
+   * it into place. A concurrent JVM landing the same file in the cache first is treated as success.
+   */
+  public boolean downloadToFile(MavenLocation location, File toFile) {
+    Path tempFile;
+    try {
+      Files.createDirectories(tempDir.toPath());
+      tempFile = Files.createTempFile(tempDir.toPath(), location.getFilename() + "-", ".tmp");
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to create temp file under " + tempDir, e);
+    }
+    try {
+      if (!doDownload(location, tempFile)) {
+        return false;
+      }
+      moveFile(tempFile, toFile.toPath());
+      return true;
+    } finally {
+      try {
+        Files.deleteIfExists(tempFile);
+      } catch (IOException e) {
+        LOG.debug("Could not delete temp file {}: {}", tempFile, e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Fetch the artifact bytes into {@code destination}. Subclasses choose which Artifactory repository (or
+   * repositories) to try. Returns {@code true} on success.
+   */
+  protected abstract boolean doDownload(MavenLocation location, Path destination);
 
   public abstract Optional<File> downloadToDir(MavenLocation location, File toDir);
 

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/Artifactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/Artifactory.java
@@ -26,6 +26,7 @@ import com.sonar.orchestrator.http.HttpClientFactory;
 import com.sonar.orchestrator.http.HttpException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -96,6 +97,8 @@ public abstract class Artifactory {
       LOG.warn("Falling back to a non-atomic move");
       try {
         Files.move(source, target);
+      } catch (FileAlreadyExistsException e2) {
+        LOG.debug("File {} was cached concurrently during fallback; discarding our copy {}", target, source);
       } catch (IOException e2) {
         throw new IllegalStateException("Fail to move file " + target, e2);
       }

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/Artifactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/Artifactory.java
@@ -121,20 +121,6 @@ public abstract class Artifactory {
     }
   }
 
-  protected Optional<File> downloadToDir(MavenLocation location, File toDir, @Nullable String repository) {
-    HttpUrl url = buildArtifactUrl(location, repository);
-    HttpCall call = newArtifactoryCall(url);
-    try {
-      LOG.info("Downloading {}", url);
-      File toFile = call.downloadToDirectory(toDir);
-      LOG.info("Found {} at {}", location, url);
-      return Optional.of(toFile);
-    } catch (HttpException e) {
-      handleDownloadFailure(e, url, repository);
-      return Optional.empty();
-    }
-  }
-
   private HttpUrl buildArtifactUrl(MavenLocation location, @Nullable String repository) {
     HttpUrl.Builder urlBuilder = HttpUrl.parse(baseUrl).newBuilder();
     if (!isEmpty(repository)) {
@@ -224,7 +210,5 @@ public abstract class Artifactory {
    * repositories) to try. Returns {@code true} on success.
    */
   protected abstract boolean doDownload(MavenLocation location, Path destination);
-
-  public abstract Optional<File> downloadToDir(MavenLocation location, File toDir);
 
 }

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
@@ -38,7 +38,7 @@ public class ArtifactoryFactory {
    * </p>
    */
   public static Artifactory createArtifactory(Configuration configuration) {
-    File downloadTempDir = new File(configuration.fileSystem().workspace().toFile(), "temp-downloads");
+    File downloadTempDir = configuration.fileSystem().getTempDir().toFile();
     String baseUrl = defaultIfEmpty(configuration.getStringByKeys("orchestrator.artifactory.url", "ARTIFACTORY_URL"), DEFAULT_ARTIFACTORY_URL);
 
     if (baseUrl.startsWith(DEFAULT_ARTIFACTORY_PREFIX)) {

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/DefaultArtifactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/DefaultArtifactory.java
@@ -61,17 +61,6 @@ public class DefaultArtifactory extends Artifactory {
   }
 
   @Override
-  public Optional<File> downloadToDir(MavenLocation location, File toDir) {
-    for (String repository : asList("sonarsource", "sonarsource-qa")) {
-      Optional<File> optionalFile = super.downloadToDir(location, toDir, repository);
-      if (optionalFile.isPresent()) {
-        return optionalFile;
-      }
-    }
-    return Optional.empty();
-  }
-
-  @Override
   public Optional<String> resolveVersion(MavenLocation location) {
     String repositories;
     if (location.getVersion().startsWith("LATEST_RELEASE")) {

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/DefaultArtifactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/DefaultArtifactory.java
@@ -25,6 +25,7 @@ import com.eclipsesource.json.JsonValue;
 import com.sonar.orchestrator.config.Configuration;
 import com.sonar.orchestrator.http.HttpCall;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
@@ -42,7 +43,7 @@ public class DefaultArtifactory extends Artifactory {
   }
 
   protected static DefaultArtifactory create(Configuration configuration) {
-    File downloadTempDir = new File(configuration.fileSystem().workspace().toFile(), "temp-downloads");
+    File downloadTempDir = configuration.fileSystem().getTempDir().toFile();
     String baseUrl = defaultIfEmpty(configuration.getStringByKeys("orchestrator.artifactory.url", "ARTIFACTORY_URL"), "https://repox.jfrog.io/repox");
     String apiKey = configuration.getStringByKeys("orchestrator.artifactory.apiKey", "ARTIFACTORY_API_KEY");
     String accessToken = configuration.getStringByKeys("orchestrator.artifactory.accessToken", "ARTIFACTORY_ACCESS_TOKEN");
@@ -50,9 +51,13 @@ public class DefaultArtifactory extends Artifactory {
   }
 
   @Override
-  public boolean downloadToFile(MavenLocation location, File toFile) {
-    Optional<File> tempFile = this.downloadToDir(location, tempDir);
-    return tempFile.filter(file -> super.moveFile(file, toFile)).isPresent();
+  protected boolean doDownload(MavenLocation location, Path destination) {
+    for (String repository : asList("sonarsource", "sonarsource-qa")) {
+      if (super.downloadFromRepository(location, destination, repository)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/MavenArtifactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/MavenArtifactory.java
@@ -20,6 +20,7 @@
 package com.sonar.orchestrator.locator;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Optional;
 
 public class MavenArtifactory extends Artifactory {
@@ -47,9 +48,8 @@ public class MavenArtifactory extends Artifactory {
   }
 
   @Override
-  public boolean downloadToFile(MavenLocation location, File toFile) {
-    Optional<File> tempFile = super.downloadToDir(location, tempDir, null);
-    return tempFile.filter(file -> super.moveFile(file, toFile)).isPresent();
+  protected boolean doDownload(MavenLocation location, Path destination) {
+    return super.downloadFromRepository(location, destination, null);
   }
 
   @Override

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/MavenArtifactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/MavenArtifactory.java
@@ -52,11 +52,6 @@ public class MavenArtifactory extends Artifactory {
     return super.downloadFromRepository(location, destination, null);
   }
 
-  @Override
-  public Optional<File> downloadToDir(MavenLocation location, File toDir) {
-    return super.downloadToDir(location, toDir, null);
-  }
-
   private static boolean isUnsupportedVersionAlias(String version) {
     return version.startsWith("DEV") || version.startsWith("LTS") || version.contains("COMPATIBLE");
   }

--- a/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/ArtifactoryTest.java
+++ b/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/ArtifactoryTest.java
@@ -1,0 +1,103 @@
+/*
+ * Orchestrator Locators
+ * Copyright (C) 2011-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.orchestrator.locator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ArtifactoryTest {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private final Artifactory underTest = new Artifactory(null, "https://example.com", null, null) {
+    @Override
+    public Optional<String> resolveVersion(MavenLocation location) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected boolean doDownload(MavenLocation location, Path destination) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<File> downloadToDir(MavenLocation location, File toDir) {
+      throw new UnsupportedOperationException();
+    }
+  };
+
+  @Test
+  public void moveFile_moves_source_into_target() throws IOException {
+    Path source = temp.newFile().toPath();
+    Files.writeString(source, "payload", StandardCharsets.UTF_8);
+    Path target = new File(temp.newFolder(), "target.jar").toPath();
+
+    underTest.moveFile(source, target);
+
+    assertThat(target).exists().hasContent("payload");
+    assertThat(source).doesNotExist();
+  }
+
+  @Test
+  public void moveFile_creates_missing_parent_directory_of_target() throws IOException {
+    Path source = temp.newFile().toPath();
+    Files.writeString(source, "payload", StandardCharsets.UTF_8);
+    Path missingParent = temp.newFolder().toPath().resolve("nested").resolve("dir");
+    Path target = missingParent.resolve("target.jar");
+
+    underTest.moveFile(source, target);
+
+    assertThat(target).exists().hasContent("payload");
+    assertThat(missingParent).isDirectory();
+  }
+
+  @Test
+  public void moveFile_returns_silently_when_target_already_exists_as_concurrent_winner() throws IOException {
+    Path source = temp.newFolder().toPath().resolve("missing-source.tmp");
+    Path target = new File(temp.newFolder(), "target.jar").toPath();
+    Files.writeString(target, "already_there", StandardCharsets.UTF_8);
+
+    underTest.moveFile(source, target);
+
+    assertThat(target).hasContent("already_there");
+    assertThat(source).doesNotExist();
+  }
+
+  @Test
+  public void moveFile_throws_ISE_when_source_does_not_exist_and_target_does_not_exist() throws IOException {
+    Path source = temp.newFolder().toPath().resolve("missing-source.tmp");
+    Path target = new File(temp.newFolder(), "missing-target.jar").toPath();
+
+    assertThatThrownBy(() -> underTest.moveFile(source, target))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageStartingWith("Fail to move file " + target);
+  }
+}

--- a/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/ArtifactoryTest.java
+++ b/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/ArtifactoryTest.java
@@ -47,11 +47,6 @@ public class ArtifactoryTest {
     protected boolean doDownload(MavenLocation location, Path destination) {
       throw new UnsupportedOperationException();
     }
-
-    @Override
-    public Optional<File> downloadToDir(MavenLocation location, File toDir) {
-      throw new UnsupportedOperationException();
-    }
   };
 
   @Test

--- a/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
+++ b/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
@@ -409,63 +409,6 @@ public class DefaultArtifactoryTest {
   }
 
   @Test
-  public void downloadToDir_returns_file_in_target_dir_on_success() throws Exception {
-    prepareDownload("this_is_bytecode");
-
-    Configuration configuration = newConfiguration().build();
-    Artifactory underTest = DefaultArtifactory.create(configuration);
-    File targetDir = temp.newFolder();
-
-    Optional<File> result = underTest.downloadToDir(SONAR_JAVA_4_5, targetDir);
-
-    assertThat(result).isPresent();
-    assertThat(result.get())
-      .hasParent(targetDir)
-      .hasName("sonar-java-4.5.jar")
-      .hasContent("this_is_bytecode");
-
-    RecordedRequest request = mockWebServerRule.getServer().takeRequest();
-    assertThat(request.getTarget()).isEqualTo("/sonarsource/org/sonarsource/java/sonar-java/4.5/sonar-java-4.5.jar");
-  }
-
-  @Test
-  public void downloadToDir_falls_back_to_second_repository_on_first_repository_failure() throws Exception {
-    prepareResponseError(404);
-    prepareDownload("this_is_bytecode");
-
-    Configuration configuration = newConfiguration().build();
-    Artifactory underTest = DefaultArtifactory.create(configuration);
-    File targetDir = temp.newFolder();
-
-    Optional<File> result = underTest.downloadToDir(SONAR_JAVA_4_5, targetDir);
-
-    assertThat(result).isPresent();
-    assertThat(result.get())
-      .hasParent(targetDir)
-      .hasContent("this_is_bytecode");
-
-    RecordedRequest request1 = mockWebServerRule.getServer().takeRequest();
-    assertThat(request1.getTarget()).isEqualTo("/sonarsource/org/sonarsource/java/sonar-java/4.5/sonar-java-4.5.jar");
-    RecordedRequest request2 = mockWebServerRule.getServer().takeRequest();
-    assertThat(request2.getTarget()).isEqualTo("/sonarsource-qa/org/sonarsource/java/sonar-java/4.5/sonar-java-4.5.jar");
-  }
-
-  @Test
-  public void downloadToDir_returns_empty_when_both_repositories_fail() throws Exception {
-    prepareResponseError(404);
-    prepareResponseError(404);
-
-    Configuration configuration = newConfiguration().build();
-    Artifactory underTest = DefaultArtifactory.create(configuration);
-    File targetDir = temp.newFolder();
-
-    Optional<File> result = underTest.downloadToDir(SONAR_JAVA_4_5, targetDir);
-
-    assertThat(result).isEmpty();
-    assertThat(targetDir).isEmptyDirectory();
-  }
-
-  @Test
   public void downloadToFile_succeeds_and_cleans_temp_when_target_already_exists() throws Exception {
     prepareDownload("freshly_downloaded_bytes");
 

--- a/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
+++ b/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
@@ -26,7 +26,17 @@ import com.eclipsesource.json.JsonValue;
 import com.sonar.orchestrator.config.Configuration;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
@@ -68,7 +78,7 @@ public class DefaultArtifactoryTest {
       .build();
     Artifactory underTest = DefaultArtifactory.create(configuration);
 
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
     assertThat(found).isTrue();
@@ -90,7 +100,7 @@ public class DefaultArtifactoryTest {
       .build();
     Artifactory underTest = DefaultArtifactory.create(configuration);
 
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
     assertThat(found).isTrue();
@@ -116,7 +126,7 @@ public class DefaultArtifactoryTest {
       .build();
     Artifactory underTest = DefaultArtifactory.create(configuration);
 
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
     assertThat(found).isTrue();
@@ -137,7 +147,7 @@ public class DefaultArtifactoryTest {
       .build();
     Artifactory underTest = DefaultArtifactory.create(configuration);
 
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
     assertThat(found).isTrue();
@@ -156,7 +166,7 @@ public class DefaultArtifactoryTest {
     prepareResponseError(401);
     Configuration configuration = newConfiguration().build();
 
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     Artifactory underTest = DefaultArtifactory.create(configuration);
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
@@ -170,7 +180,7 @@ public class DefaultArtifactoryTest {
     prepareResponseError(403, "not found");
     Configuration configuration = newConfiguration().build();
 
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     Artifactory underTest = DefaultArtifactory.create(configuration);
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
@@ -184,7 +194,7 @@ public class DefaultArtifactoryTest {
     prepareResponseError(404);
     Configuration configuration = newConfiguration().build();
 
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     Artifactory underTest = DefaultArtifactory.create(configuration);
     boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
 
@@ -195,7 +205,7 @@ public class DefaultArtifactoryTest {
   public void download_throws_ISE_if_unexpected_error() throws Exception {
     prepareResponseError(500);
     Configuration configuration = newConfiguration().build();
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     Artifactory underTest = DefaultArtifactory.create(configuration);
 
     expectedException.expect(IllegalStateException.class);
@@ -396,6 +406,120 @@ public class DefaultArtifactoryTest {
   private void verifyVersionsRequest(String groupId, String artifactId, String versionLayout, String repositories) throws InterruptedException {
     RecordedRequest request = mockWebServerRule.getServer().takeRequest();
     assertThat(request.getTarget()).isEqualTo("/api/search/versions?g=" + groupId + "&a=" + artifactId + "&remote=0&repos=" + repositories + "&v=" + versionLayout);
+  }
+
+  @Test
+  public void downloadToDir_returns_file_in_target_dir_on_success() throws Exception {
+    prepareDownload("this_is_bytecode");
+
+    Configuration configuration = newConfiguration().build();
+    Artifactory underTest = DefaultArtifactory.create(configuration);
+    File targetDir = temp.newFolder();
+
+    Optional<File> result = underTest.downloadToDir(SONAR_JAVA_4_5, targetDir);
+
+    assertThat(result).isPresent();
+    assertThat(result.get())
+      .hasParent(targetDir)
+      .hasName("sonar-java-4.5.jar")
+      .hasContent("this_is_bytecode");
+
+    RecordedRequest request = mockWebServerRule.getServer().takeRequest();
+    assertThat(request.getTarget()).isEqualTo("/sonarsource/org/sonarsource/java/sonar-java/4.5/sonar-java-4.5.jar");
+  }
+
+  @Test
+  public void downloadToDir_falls_back_to_second_repository_on_first_repository_failure() throws Exception {
+    prepareResponseError(404);
+    prepareDownload("this_is_bytecode");
+
+    Configuration configuration = newConfiguration().build();
+    Artifactory underTest = DefaultArtifactory.create(configuration);
+    File targetDir = temp.newFolder();
+
+    Optional<File> result = underTest.downloadToDir(SONAR_JAVA_4_5, targetDir);
+
+    assertThat(result).isPresent();
+    assertThat(result.get())
+      .hasParent(targetDir)
+      .hasContent("this_is_bytecode");
+
+    RecordedRequest request1 = mockWebServerRule.getServer().takeRequest();
+    assertThat(request1.getTarget()).isEqualTo("/sonarsource/org/sonarsource/java/sonar-java/4.5/sonar-java-4.5.jar");
+    RecordedRequest request2 = mockWebServerRule.getServer().takeRequest();
+    assertThat(request2.getTarget()).isEqualTo("/sonarsource-qa/org/sonarsource/java/sonar-java/4.5/sonar-java-4.5.jar");
+  }
+
+  @Test
+  public void downloadToDir_returns_empty_when_both_repositories_fail() throws Exception {
+    prepareResponseError(404);
+    prepareResponseError(404);
+
+    Configuration configuration = newConfiguration().build();
+    Artifactory underTest = DefaultArtifactory.create(configuration);
+    File targetDir = temp.newFolder();
+
+    Optional<File> result = underTest.downloadToDir(SONAR_JAVA_4_5, targetDir);
+
+    assertThat(result).isEmpty();
+    assertThat(targetDir).isEmptyDirectory();
+  }
+
+  @Test
+  public void downloadToFile_succeeds_and_cleans_temp_when_target_already_exists() throws Exception {
+    prepareDownload("freshly_downloaded_bytes");
+
+    Configuration configuration = newConfiguration().build();
+    Artifactory underTest = DefaultArtifactory.create(configuration);
+
+    File targetFile = new File(temp.newFolder(), "already_cached.jar");
+    Files.writeString(targetFile.toPath(), "previously_cached_bytes", StandardCharsets.UTF_8);
+
+    boolean found = underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
+
+    assertThat(found).isTrue();
+    // Platform-dependent: ATOMIC_MOVE silently overwrites on POSIX (rename semantics) and fails on Windows,
+    // in which case we accept the existing target as a concurrent winner. Both outcomes are valid for the
+    // cache contract — neither raises an exception and the file holds valid content.
+    assertThat(Files.readString(targetFile.toPath()))
+      .isIn("freshly_downloaded_bytes", "previously_cached_bytes");
+    assertThat(configuration.fileSystem().getTempDir()).isEmptyDirectory();
+  }
+
+  @Test
+  public void downloadToFile_uses_unique_temp_file_so_concurrent_downloads_do_not_collide() throws Exception {
+    int concurrency = 4;
+    for (int i = 0; i < concurrency; i++) {
+      prepareDownload("artifact_bytes");
+    }
+
+    Configuration configuration = newConfiguration()
+      .setProperty("orchestrator.artifactory.apiKey", "")
+      .build();
+    Artifactory underTest = DefaultArtifactory.create(configuration);
+
+    File cacheDir = temp.newFolder();
+    File targetFile = new File(cacheDir, "sonar-java-4.5.jar");
+
+    ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+    CountDownLatch startGate = new CountDownLatch(1);
+    try {
+      List<Future<Boolean>> futures = IntStream.range(0, concurrency)
+        .mapToObj(i -> executor.submit((Callable<Boolean>) () -> {
+          startGate.await();
+          return underTest.downloadToFile(SONAR_JAVA_4_5, targetFile);
+        }))
+        .toList();
+      startGate.countDown();
+      for (Future<Boolean> future : futures) {
+        assertThat(future.get(30, TimeUnit.SECONDS)).isTrue();
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertThat(targetFile).exists().hasContent("artifact_bytes");
+    assertThat(configuration.fileSystem().getTempDir()).isEmptyDirectory();
   }
 
   private Configuration.Builder newConfiguration() throws IOException {

--- a/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/MavenArtifactoryTest.java
+++ b/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/MavenArtifactoryTest.java
@@ -80,7 +80,7 @@ public class MavenArtifactoryTest {
 
     Artifactory underTest = getMavenArtifactory();
 
-    File targetFile = temp.newFile();
+    File targetFile = new File(temp.newFolder(), "downloaded.jar");
     boolean found = underTest.downloadToFile(SONAR_PLUGIN_API, targetFile);
 
     assertThat(found).isTrue();
@@ -89,6 +89,38 @@ public class MavenArtifactoryTest {
     RecordedRequest request = mockWebServerRule.getServer().takeRequest();
     assertThat(request.getTarget()).isEqualTo("/org/sonarsource/sonarqube/sonar-plugin-api/3.0/sonar-plugin-api-3.0.jar");
     assertThat(request.getHeaders().get("Authorization")).isNull();
+  }
+
+  @Test
+  public void downloadToDir_returns_file_in_target_dir_on_success() throws Exception {
+    prepareServerResponse("this_is_bytecode");
+
+    Artifactory underTest = getMavenArtifactory();
+    File targetDir = temp.newFolder();
+
+    Optional<File> result = underTest.downloadToDir(SONAR_PLUGIN_API, targetDir);
+
+    assertThat(result).isPresent();
+    assertThat(result.get())
+      .hasParent(targetDir)
+      .hasName("sonar-plugin-api-3.0.jar")
+      .hasContent("this_is_bytecode");
+
+    RecordedRequest request = mockWebServerRule.getServer().takeRequest();
+    assertThat(request.getTarget()).isEqualTo("/org/sonarsource/sonarqube/sonar-plugin-api/3.0/sonar-plugin-api-3.0.jar");
+  }
+
+  @Test
+  public void downloadToDir_returns_empty_when_artifact_not_found() throws Exception {
+    mockWebServerRule.getServer().enqueue(new MockResponse.Builder().code(404).build());
+
+    Artifactory underTest = getMavenArtifactory();
+    File targetDir = temp.newFolder();
+
+    Optional<File> result = underTest.downloadToDir(SONAR_PLUGIN_API, targetDir);
+
+    assertThat(result).isEmpty();
+    assertThat(targetDir).isEmptyDirectory();
   }
 
   @Test

--- a/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/MavenArtifactoryTest.java
+++ b/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/MavenArtifactoryTest.java
@@ -92,38 +92,6 @@ public class MavenArtifactoryTest {
   }
 
   @Test
-  public void downloadToDir_returns_file_in_target_dir_on_success() throws Exception {
-    prepareServerResponse("this_is_bytecode");
-
-    Artifactory underTest = getMavenArtifactory();
-    File targetDir = temp.newFolder();
-
-    Optional<File> result = underTest.downloadToDir(SONAR_PLUGIN_API, targetDir);
-
-    assertThat(result).isPresent();
-    assertThat(result.get())
-      .hasParent(targetDir)
-      .hasName("sonar-plugin-api-3.0.jar")
-      .hasContent("this_is_bytecode");
-
-    RecordedRequest request = mockWebServerRule.getServer().takeRequest();
-    assertThat(request.getTarget()).isEqualTo("/org/sonarsource/sonarqube/sonar-plugin-api/3.0/sonar-plugin-api-3.0.jar");
-  }
-
-  @Test
-  public void downloadToDir_returns_empty_when_artifact_not_found() throws Exception {
-    mockWebServerRule.getServer().enqueue(new MockResponse.Builder().code(404).build());
-
-    Artifactory underTest = getMavenArtifactory();
-    File targetDir = temp.newFolder();
-
-    Optional<File> result = underTest.downloadToDir(SONAR_PLUGIN_API, targetDir);
-
-    assertThat(result).isEmpty();
-    assertThat(targetDir).isEmptyDirectory();
-  }
-
-  @Test
   public void resolveVersion_whenLATESTRELEASE_shouldResolveToHighestAvailableVersion() throws Exception {
     prepareServerResponse(getContent());
     Artifactory underTest = getMavenArtifactory();


### PR DESCRIPTION
Two JVMs sharing the orchestrator cache could race on a shared temp filename derived from HTTP Content-Disposition and a non-atomic delete+move into the cache, failing with "Source ... does not exist".

Each download now lands in a unique temp file under <orchestratorHome>/_tmp (same filesystem as the cache) and is moved into place atomically; if another JVM cached the file first, the move accepts it as success.

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/ORCH) ticket available, please make your commits and pull request start with the ticket ID (ORCH-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
