### PR TITLE
SONAR-27955 Rename CODEOWNER from platform-onprem-squad to platform-server-squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-.github/CODEOWNERS @SonarSource/platform-onprem-squad
+.github/CODEOWNERS @SonarSource/platform-server-squad
+


### PR DESCRIPTION
Renames the CODEOWNERS reference per [SONAR-27955](https://sonarsource.atlassian.net/browse/SONAR-27955):

- `@sonarsource/platform-onprem-squad` → `@sonarsource/platform-server-squad`
- Ensures the file ends with a trailing blank line.

Follow-up to the squad rename — the team slug `platform-onprem-squad` was already renamed in GitHub to `platform-server-squad`, but this CODEOWNERS file was not yet updated.

[SONAR-27955]: https://sonarsource.atlassian.net/browse/SONAR-27955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ