### PR TITLE
NO-JIRA Update mise action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.3.13
       - uses: SonarSource/ci-github-actions/get-build-number@v1
@@ -45,7 +45,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache_save: false
           version: 2026.3.13


### PR DESCRIPTION
----
## Summary by Gitar

- **CI Configuration:**
    - Upgraded `jdx/mise-action` from `v4.0.1` to `v4.2.1` in `.github/workflows/build.yml`.

<sub>This will update automatically on new commits.</sub>