### PR TITLE
BUILD-12052 Use DefaultArtifactory for repox-internal

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestClosed_job:
     name: Pull Request Closed
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-    runs-on: sonar-xs-public
+    runs-on: warp-custom-ubuntu-24-04
     name: Build
     permissions:
       id-token: write
@@ -38,7 +38,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-    runs-on: sonar-xs-public
+    runs-on: warp-custom-ubuntu-24-04
     name: Promote
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   guard:
-    runs-on: ubuntu-latest
+    runs-on: sonar-xs
     steps:
       - name: Enforce eligible release branches
         run: |

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -14,7 +14,7 @@ jobs:
   slack-notifications:
     if: >-
       contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     steps:
       - name: Send Slack Notification
         env:

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Build and run shadow scans
     permissions:
       id-token: write

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This directory is _not_ automatically purged and may grow significantly when usi
 The test environment is configured in the file `~/.sonar/orchestrator/orchestrator.properties`:
 
     # Token used to download SonarSource private artifacts from Artifactory
-    # (https://repox.jfrog.io/repox or https://repox-internal.dev.sonar.build/artifactory).
+    # (https://repox.jfrog.io/artifactory or https://repox-internal.dev.sonar.build/artifactory).
     # Generate your identity token at https://repox.jfrog.io/ui/user_profile
     # This property can be replaced by the environment variable ARTIFACTORY_ACCESS_TOKEN.
     #orchestrator.artifactory.accessToken=xxx

--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ Aliases can be used to define the versions of SonarQube and plugins to be instal
 
 The alias `LTS` is no more supported for SonarQube since Orchestrator 3.17. It should be replaced by `LATEST_RELEASE[6.7]`.
 
-Please note that since Orchestrator 4.7, if the default value of `orchestrator.artifactory.url` (https://repox.jfrog.io/repox) is _not_ used, 
-the `DEV` alias will not work.
+Please note that since Orchestrator 4.7, version aliases such as `DEV` and `LATEST_RELEASE` require a SonarSource
+Artifactory host (`https://repox.jfrog.io` or `https://repox-internal.dev.sonar.build`). They will not work against a
+plain Maven repository URL (for example Maven Central). Version alias resolution searches Artifactory with
+`remote=1` so Edge Smart Remotes under `sonarsource-releases` / `sonarsource-builds` are included.
 
 ## Local Cache
 
@@ -81,7 +83,8 @@ This directory is _not_ automatically purged and may grow significantly when usi
 
 The test environment is configured in the file `~/.sonar/orchestrator/orchestrator.properties`:
 
-    # Token used to download SonarSource private artifacts from https://repox.jfrog.io/repox
+    # Token used to download SonarSource private artifacts from Artifactory
+    # (https://repox.jfrog.io/repox or https://repox-internal.dev.sonar.build/artifactory).
     # Generate your identity token at https://repox.jfrog.io/ui/user_profile
     # This property can be replaced by the environment variable ARTIFACTORY_ACCESS_TOKEN.
     #orchestrator.artifactory.accessToken=xxx
@@ -104,10 +107,13 @@ The test environment is configured in the file `~/.sonar/orchestrator/orchestrat
     # Default is ~/.m2/repository
     #maven.localRepository=/path/to/maven/repository
 
-    # Instance of Artifactory. Default is SonarSource's instance (https://repox.jfrog.io/repox).
+    # Instance of Artifactory. Default is SonarSource's instance (https://repox.jfrog.io/artifactory).
+    # SonarSource hosts (repox.jfrog.io and repox-internal.dev.sonar.build) use authenticated
+    # Artifactory REST APIs with orchestrator.artifactory.accessToken / ARTIFACTORY_ACCESS_TOKEN.
     # This property can be replaced by the environment variable ARTIFACTORY_URL.
     # To use maven central instead, use https://repo1.maven.org/maven2
-    # To use a custom instance, use your own URL that points to a Maven repository.
+    # To use a custom instance, use your own URL that points to a Maven repository
+    # (unauthenticated Maven layout client).
     #orchestrator.artifactory.url=https://repo1.maven.org/maven2
 
 The path to configuration file can be overridden with the system property `orchestrator.configUrl`

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
@@ -64,7 +64,16 @@ public class ArtifactoryFactory {
   }
 
   private static boolean isSonarSourceArtifactory(String baseUrl) {
-    return SONARSOURCE_ARTIFACTORY_PREFIXES.stream().anyMatch(baseUrl::startsWith);
+    okhttp3.HttpUrl url = okhttp3.HttpUrl.parse(baseUrl);
+    if (url == null) {
+      return false;
+    }
+
+    String host = url.host();
+    return SONARSOURCE_ARTIFACTORY_PREFIXES.stream()
+      .map(okhttp3.HttpUrl::parse)
+      .filter(java.util.Objects::nonNull)
+      .anyMatch(allowed -> allowed.host().equals(host));
   }
 
   private ArtifactoryFactory() {

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/ArtifactoryFactory.java
@@ -21,6 +21,7 @@ package com.sonar.orchestrator.locator;
 
 import com.sonar.orchestrator.config.Configuration;
 import java.io.File;
+import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
@@ -30,24 +31,40 @@ public class ArtifactoryFactory {
   private static final String DEFAULT_ARTIFACTORY_URL = DEFAULT_ARTIFACTORY_PREFIX + "/artifactory";
 
   /**
+   * Hosts that speak Artifactory REST APIs and require SonarSource credentials
+   * ({@code ARTIFACTORY_ACCESS_TOKEN} / {@code orchestrator.artifactory.accessToken}).
+   */
+  private static final List<String> SONARSOURCE_ARTIFACTORY_PREFIXES = List.of(
+    DEFAULT_ARTIFACTORY_PREFIX,
+    "https://repox-internal.dev.sonar.build"
+  );
+
+  /**
    * Two types of Artifactory are supported: Maven and Default.
    *
    * <p>
-   * Default repox artifactory is used if orchestrator.artifactory.url is empty or specifically set to <a href="https://repox.jfrog.io/repox">repox</a>.
-   * Otherwise, we assume the URL points to a maven repository.
+   * Authenticated {@link DefaultArtifactory} is used when {@code orchestrator.artifactory.url} is empty
+   * or points at a known SonarSource Artifactory host
+   * ({@code https://repox.jfrog.io} or {@code https://repox-internal.dev.sonar.build}).
+   * Otherwise, we assume the URL points to a plain Maven repository and use unauthenticated
+   * {@link MavenArtifactory}.
    * </p>
    */
   public static Artifactory createArtifactory(Configuration configuration) {
     File downloadTempDir = configuration.fileSystem().getTempDir().toFile();
     String baseUrl = defaultIfEmpty(configuration.getStringByKeys("orchestrator.artifactory.url", "ARTIFACTORY_URL"), DEFAULT_ARTIFACTORY_URL);
 
-    if (baseUrl.startsWith(DEFAULT_ARTIFACTORY_PREFIX)) {
+    if (isSonarSourceArtifactory(baseUrl)) {
       String accessToken = configuration.getStringByKeys("orchestrator.artifactory.accessToken", "ARTIFACTORY_ACCESS_TOKEN");
       String apiKey = configuration.getStringByKeys("orchestrator.artifactory.apiKey", "ARTIFACTORY_API_KEY");
       return new DefaultArtifactory(downloadTempDir, baseUrl, accessToken, apiKey);
     } else {
       return new MavenArtifactory(downloadTempDir, baseUrl);
     }
+  }
+
+  private static boolean isSonarSourceArtifactory(String baseUrl) {
+    return SONARSOURCE_ARTIFACTORY_PREFIXES.stream().anyMatch(baseUrl::startsWith);
   }
 
   private ArtifactoryFactory() {

--- a/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/DefaultArtifactory.java
+++ b/sonar-orchestrator-locators/src/main/java/com/sonar/orchestrator/locator/DefaultArtifactory.java
@@ -79,7 +79,10 @@ public class DefaultArtifactory extends Artifactory {
       .addPathSegments("api/search/versions")
       .addQueryParameter("g", location.getGroupId())
       .addQueryParameter("a", location.getArtifactId())
-      .addQueryParameter("remote", "0")
+      // remote=1 is required for Edge (repox-internal): sonarsource-releases/builds are virtuals of
+      // Smart Remotes, and Artifactory skips remotes when remote=0 (returns 404 "Unable to find
+      // artifact versions"). SaaS still works with remote=1 because locals are always searched.
+      .addQueryParameter("remote", "1")
       .addQueryParameter("repos", repositories)
       .addQueryParameter("v", extractVersionFromAlias(location.getVersion()) + "*")
       .build();

--- a/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/ArtifactoryFactoryTest.java
+++ b/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/ArtifactoryFactoryTest.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class ArtifactoryFactoryTest {
 
   private static final String DEFAULT_REPOSITORY = "https://repox.jfrog.io/artifactory";
+  private static final String INTERNAL_REPOSITORY = "https://repox-internal.dev.sonar.build/artifactory";
   private static final String SOME_MAVEN_REPOSITORY = "https://localhost:9000/maven-repo";
   private static final String ACCESS_TOKEN = "access_token";
   private static final String API_KEY = "api_key";
@@ -64,6 +65,7 @@ class ArtifactoryFactoryTest {
       Arguments.of(new Parameters(null, DEFAULT_REPOSITORY, API_KEY, API_KEY, ACCESS_TOKEN, ACCESS_TOKEN, DefaultArtifactory.class)),
       Arguments.of(new Parameters("", DEFAULT_REPOSITORY, API_KEY, API_KEY, ACCESS_TOKEN, ACCESS_TOKEN, DefaultArtifactory.class)),
       Arguments.of(new Parameters(DEFAULT_REPOSITORY, DEFAULT_REPOSITORY, API_KEY, API_KEY, ACCESS_TOKEN, ACCESS_TOKEN, DefaultArtifactory.class)),
+      Arguments.of(new Parameters(INTERNAL_REPOSITORY, INTERNAL_REPOSITORY, API_KEY, API_KEY, ACCESS_TOKEN, ACCESS_TOKEN, DefaultArtifactory.class)),
       Arguments.of(new Parameters(SOME_MAVEN_REPOSITORY, SOME_MAVEN_REPOSITORY, API_KEY, null, ACCESS_TOKEN, null, MavenArtifactory.class))
     );
   }

--- a/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
+++ b/sonar-orchestrator-locators/src/test/java/com/sonar/orchestrator/locator/DefaultArtifactoryTest.java
@@ -405,7 +405,7 @@ public class DefaultArtifactoryTest {
 
   private void verifyVersionsRequest(String groupId, String artifactId, String versionLayout, String repositories) throws InterruptedException {
     RecordedRequest request = mockWebServerRule.getServer().takeRequest();
-    assertThat(request.getTarget()).isEqualTo("/api/search/versions?g=" + groupId + "&a=" + artifactId + "&remote=0&repos=" + repositories + "&v=" + versionLayout);
+    assertThat(request.getTarget()).isEqualTo("/api/search/versions?g=" + groupId + "&a=" + artifactId + "&remote=1&repos=" + repositories + "&v=" + versionLayout);
   }
 
   @Test


### PR DESCRIPTION
## Summary
BUILD-12052 Make Orchestrator work against `repox-internal` (JFrog Edge):

1. Use authenticated `DefaultArtifactory` for `https://repox-internal.dev.sonar.build` (not unauthenticated `MavenArtifactory`).
2. Search version aliases with `remote=1` so Edge Smart Remotes under `sonarsource-releases` / `sonarsource-builds` are included.
3. CI uses released `SonarSource/ci-github-actions/build-maven@v1`.

## Test plan
- [x] CI green on this PR (Build + Promote)
- [x] After promote, bump Orchestrator in `sonar-enterprise` #17688 and re-run IT against `repox-internal`: https://github.com/SonarSource/sonar-enterprise/pull/17688