### PR TITLE
BUILD-12052 Use github-ubuntu-latest-s for Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: github-ubuntu-latest-s
     name: Build
     permissions:
       id-token: write
@@ -38,7 +38,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: github-ubuntu-latest-s
     name: Promote
     permissions:
       id-token: write


### PR DESCRIPTION
BUILD-12052 Patch master Build failures after #420.

## Summary
- Switch Build and Promote jobs from `warp-custom-ubuntu-24-04` to `github-ubuntu-latest-s`.
- Addresses [failed master Build](https://github.com/SonarSource/orchestrator/actions/runs/30341620375/job/90220995878) where `MavenVersionResolverTest` hit Maven Central HTTP 429s.

## Test plan
- [ ] Build + Promote green on this PR
- [ ] Confirm master Build recovers after merge