### PR TITLE
ORCH-562 Skip JRE system truststore lookup for scanner builds

### DIFF
--- a/echo/pom.xml
+++ b/echo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>echo</artifactId>
   <name>Echo Program</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.sonarsource.orchestrator</groupId>
   <artifactId>orchestrator-parent</artifactId>
-  <version>6.4.0-SNAPSHOT</version>
+  <version>6.4.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Orchestrator :: Parent</name>
   <inceptionYear>2011</inceptionYear>

--- a/sonar-orchestrator-build/pom.xml
+++ b/sonar-orchestrator-build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-build</artifactId>
   <name>Orchestrator Build</name>

--- a/sonar-orchestrator-build/src/main/java/com/sonar/orchestrator/build/BuildRunner.java
+++ b/sonar-orchestrator-build/src/main/java/com/sonar/orchestrator/build/BuildRunner.java
@@ -29,6 +29,7 @@ public class BuildRunner {
 
   public static final String SONAR_HOST_URL = "sonar.host.url";
   private static final String FAIL_ON_DUPLICATE_TELEMETRY_KEY = "sonar.scanner.internal.failOnDuplicateTelemetryKey";
+  private static final String SKIP_JRE_SYSTEM_TRUSTSTORE = "sonar.scanner.skipSystemTruststore";
   private final Configuration config;
   private final Locators locators;
 
@@ -58,6 +59,7 @@ public class BuildRunner {
       adjustedProperties.put("sonar.scm.disabled", "true");
       adjustedProperties.put("sonar.branch.autoconfig.disabled", "true");
       adjustedProperties.put(FAIL_ON_DUPLICATE_TELEMETRY_KEY, "true");
+      adjustedProperties.put(SKIP_JRE_SYSTEM_TRUSTSTORE, "true");
     }
     // build properties override predefined properties
     adjustedProperties.putAll(build.getProperties());

--- a/sonar-orchestrator-build/src/test/java/com/sonar/orchestrator/build/BuildRunnerTest.java
+++ b/sonar-orchestrator-build/src/test/java/com/sonar/orchestrator/build/BuildRunnerTest.java
@@ -61,7 +61,8 @@ public class BuildRunnerTest {
       entry("language", "java"),
       entry("sonar.scm.disabled", "true"),
       entry("sonar.branch.autoconfig.disabled", "true"),
-      entry("sonar.scanner.internal.failOnDuplicateTelemetryKey", "true"));
+      entry("sonar.scanner.internal.failOnDuplicateTelemetryKey", "true"),
+      entry("sonar.scanner.skipSystemTruststore", "true"));
   }
 
   @Test
@@ -83,7 +84,8 @@ public class BuildRunnerTest {
       entry("language", "java"),
       entry("sonar.scm.disabled", "true"),
       entry("sonar.branch.autoconfig.disabled", "true"),
-      entry("sonar.scanner.internal.failOnDuplicateTelemetryKey", "true"));
+      entry("sonar.scanner.internal.failOnDuplicateTelemetryKey", "true"),
+      entry("sonar.scanner.skipSystemTruststore", "true"));
   }
 
   @Test

--- a/sonar-orchestrator-config/pom.xml
+++ b/sonar-orchestrator-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-config</artifactId>
   <name>Orchestrator Configuration</name>

--- a/sonar-orchestrator-http/pom.xml
+++ b/sonar-orchestrator-http/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-http</artifactId>
   <name>Orchestrator Http Client</name>

--- a/sonar-orchestrator-junit4/pom.xml
+++ b/sonar-orchestrator-junit4/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-junit4</artifactId>
   <name>Orchestrator - JUnit 4</name>

--- a/sonar-orchestrator-junit5/pom.xml
+++ b/sonar-orchestrator-junit5/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-junit5</artifactId>
   <name>Orchestrator - JUnit 5</name>

--- a/sonar-orchestrator-locators/pom.xml
+++ b/sonar-orchestrator-locators/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-locators</artifactId>
   <name>Orchestrator Locators</name>

--- a/sonar-orchestrator-utils/pom.xml
+++ b/sonar-orchestrator-utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-utils</artifactId>
   <name>Orchestrator Utils</name>

--- a/sonar-orchestrator/pom.xml
+++ b/sonar-orchestrator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator</artifactId>
   <name>Orchestrator</name>


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/ORCH-562

Setting truststore for **each** analysis that we run on our IT (and we run hundreds of them) is long, expensive, and its own JavaDoc says that it can get stuck or be slow. There is no need for that as in our ITs we are running analysis against localhost, so we don't even use SSL.
More details in the ticket.