### PR TITLE
ORCH-563 Skip redundant BouncyCastle JVM truststore reload for scanner builds

### DIFF
--- a/echo/pom.xml
+++ b/echo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>echo</artifactId>
   <name>Echo Program</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.sonarsource.orchestrator</groupId>
   <artifactId>orchestrator-parent</artifactId>
-  <version>6.4.1-SNAPSHOT</version>
+  <version>6.4.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Orchestrator :: Parent</name>
   <inceptionYear>2011</inceptionYear>

--- a/sonar-orchestrator-build/pom.xml
+++ b/sonar-orchestrator-build/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-build</artifactId>
   <name>Orchestrator Build</name>

--- a/sonar-orchestrator-build/src/main/java/com/sonar/orchestrator/build/BuildRunner.java
+++ b/sonar-orchestrator-build/src/main/java/com/sonar/orchestrator/build/BuildRunner.java
@@ -61,12 +61,25 @@ public class BuildRunner {
       adjustedProperties.put("sonar.branch.autoconfig.disabled", "true");
       adjustedProperties.put(FAIL_ON_DUPLICATE_TELEMETRY_KEY, "true");
       adjustedProperties.put(SKIP_JRE_SYSTEM_TRUSTSTORE, "true");
-      adjustedProperties.put(SKIP_JVM_SSL_CONFIG, "true");
+      if (isPlainHttpOrUnknown(build.getProperties().getOrDefault(SONAR_HOST_URL, serverUrl))) {
+        adjustedProperties.put(SKIP_JVM_SSL_CONFIG, "true");
+      }
     }
     // build properties override predefined properties
     adjustedProperties.putAll(build.getProperties());
 
     return adjustedProperties;
+  }
+
+  /**
+   * The JVM SSL config skip is only safe for endpoints we control: a null host means the
+   * default orchestrator-managed local server (plain HTTP), and an explicit {@code http://}
+   * URL cannot rely on the JVM's SSL properties in the first place. Any {@code https://}
+   * target may depend on {@code javax.net.ssl.trustStore}/{@code keyStore} for a custom
+   * CA or client certificate, which {@code sonar.scanner.skipJvmSslConfig=true} would drop.
+   */
+  private static boolean isPlainHttpOrUnknown(@Nullable String hostUrl) {
+    return hostUrl == null || hostUrl.startsWith("http://");
   }
 
 }

--- a/sonar-orchestrator-build/src/main/java/com/sonar/orchestrator/build/BuildRunner.java
+++ b/sonar-orchestrator-build/src/main/java/com/sonar/orchestrator/build/BuildRunner.java
@@ -30,6 +30,7 @@ public class BuildRunner {
   public static final String SONAR_HOST_URL = "sonar.host.url";
   private static final String FAIL_ON_DUPLICATE_TELEMETRY_KEY = "sonar.scanner.internal.failOnDuplicateTelemetryKey";
   private static final String SKIP_JRE_SYSTEM_TRUSTSTORE = "sonar.scanner.skipSystemTruststore";
+  private static final String SKIP_JVM_SSL_CONFIG = "sonar.scanner.skipJvmSslConfig";
   private final Configuration config;
   private final Locators locators;
 
@@ -60,6 +61,7 @@ public class BuildRunner {
       adjustedProperties.put("sonar.branch.autoconfig.disabled", "true");
       adjustedProperties.put(FAIL_ON_DUPLICATE_TELEMETRY_KEY, "true");
       adjustedProperties.put(SKIP_JRE_SYSTEM_TRUSTSTORE, "true");
+      adjustedProperties.put(SKIP_JVM_SSL_CONFIG, "true");
     }
     // build properties override predefined properties
     adjustedProperties.putAll(build.getProperties());

--- a/sonar-orchestrator-build/src/test/java/com/sonar/orchestrator/build/BuildRunnerTest.java
+++ b/sonar-orchestrator-build/src/test/java/com/sonar/orchestrator/build/BuildRunnerTest.java
@@ -67,6 +67,51 @@ public class BuildRunnerTest {
   }
 
   @Test
+  public void dont_skip_jvm_ssl_config_when_build_overrides_host_url_to_https() {
+    Configuration config = Configuration.create();
+    Build build = mock(Build.class);
+    when(build.getProperties()).thenReturn(Map.of("sonar.host.url", "https://localhost:9443", "language", "java"));
+
+    BuildRunner runner = new BuildRunner(config, null);
+    // serverUrl is the orchestrator-managed (plain HTTP) server; the build itself targets a different HTTPS endpoint
+    runner.runQuietly("http://localhost:9000", build);
+
+    ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+
+    verify(build).execute(eq(config), isNull(), captor.capture());
+
+    assertThat(captor.getValue()).containsOnly(
+      entry("sonar.host.url", "https://localhost:9443"),
+      entry("language", "java"),
+      entry("sonar.scm.disabled", "true"),
+      entry("sonar.branch.autoconfig.disabled", "true"),
+      entry("sonar.scanner.internal.failOnDuplicateTelemetryKey", "true"),
+      entry("sonar.scanner.skipSystemTruststore", "true"));
+  }
+
+  @Test
+  public void skip_jvm_ssl_config_when_server_url_is_null() {
+    Configuration config = Configuration.create();
+    Build build = mock(Build.class);
+    when(build.getProperties()).thenReturn(Map.of("language", "java"));
+
+    BuildRunner runner = new BuildRunner(config, null);
+    runner.runQuietly(null, build);
+
+    ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+
+    verify(build).execute(eq(config), isNull(), captor.capture());
+
+    assertThat(captor.getValue()).containsOnly(
+      entry("language", "java"),
+      entry("sonar.scm.disabled", "true"),
+      entry("sonar.branch.autoconfig.disabled", "true"),
+      entry("sonar.scanner.internal.failOnDuplicateTelemetryKey", "true"),
+      entry("sonar.scanner.skipSystemTruststore", "true"),
+      entry("sonar.scanner.skipJvmSslConfig", "true"));
+  }
+
+  @Test
   public void inject_properties_for_msbuild_start() {
     Configuration config = Configuration.create();
     Build build = mock(ScannerForMSBuild.class);

--- a/sonar-orchestrator-build/src/test/java/com/sonar/orchestrator/build/BuildRunnerTest.java
+++ b/sonar-orchestrator-build/src/test/java/com/sonar/orchestrator/build/BuildRunnerTest.java
@@ -62,7 +62,8 @@ public class BuildRunnerTest {
       entry("sonar.scm.disabled", "true"),
       entry("sonar.branch.autoconfig.disabled", "true"),
       entry("sonar.scanner.internal.failOnDuplicateTelemetryKey", "true"),
-      entry("sonar.scanner.skipSystemTruststore", "true"));
+      entry("sonar.scanner.skipSystemTruststore", "true"),
+      entry("sonar.scanner.skipJvmSslConfig", "true"));
   }
 
   @Test
@@ -85,7 +86,8 @@ public class BuildRunnerTest {
       entry("sonar.scm.disabled", "true"),
       entry("sonar.branch.autoconfig.disabled", "true"),
       entry("sonar.scanner.internal.failOnDuplicateTelemetryKey", "true"),
-      entry("sonar.scanner.skipSystemTruststore", "true"));
+      entry("sonar.scanner.skipSystemTruststore", "true"),
+      entry("sonar.scanner.skipJvmSslConfig", "true"));
   }
 
   @Test

--- a/sonar-orchestrator-config/pom.xml
+++ b/sonar-orchestrator-config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-config</artifactId>
   <name>Orchestrator Configuration</name>

--- a/sonar-orchestrator-http/pom.xml
+++ b/sonar-orchestrator-http/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-http</artifactId>
   <name>Orchestrator Http Client</name>

--- a/sonar-orchestrator-junit4/pom.xml
+++ b/sonar-orchestrator-junit4/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-junit4</artifactId>
   <name>Orchestrator - JUnit 4</name>

--- a/sonar-orchestrator-junit5/pom.xml
+++ b/sonar-orchestrator-junit5/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-junit5</artifactId>
   <name>Orchestrator - JUnit 5</name>

--- a/sonar-orchestrator-locators/pom.xml
+++ b/sonar-orchestrator-locators/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-locators</artifactId>
   <name>Orchestrator Locators</name>

--- a/sonar-orchestrator-utils/pom.xml
+++ b/sonar-orchestrator-utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator-utils</artifactId>
   <name>Orchestrator Utils</name>

--- a/sonar-orchestrator/pom.xml
+++ b/sonar-orchestrator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.orchestrator</groupId>
     <artifactId>orchestrator-parent</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>6.4.2-SNAPSHOT</version>
   </parent>
   <artifactId>sonar-orchestrator</artifactId>
   <name>Orchestrator</name>


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/ORCH-563

## What / why

Follow-up to ORCH-562 ([#422](https://github.com/SonarSource/orchestrator/pull/422)). That fix set `sonar.scanner.skipSystemTruststore=true` to skip an unconditional OS trust-store scan. It shipped in 6.4.1, which we released and bumped `sonar-enterprise` to — but measuring real CI logs afterward showed almost no improvement: the ~2.3s per-scanner-invocation gap (paid twice per invocation - bootstrap process + forked engine process) was still there, basically unchanged.

### Root cause (confirmed via a verbose scanner log, not just code reading)

One CI run happened to have `-Dsonar.verbose=true` on a scanner invocation, exposing DEBUG output that pinpoints the real cost:

```
09:53:46.278 DEBUG Using JVM default truststore: .../cacerts
                              ← 2.11s silent gap →
09:53:48.389 DEBUG Loaded truststore from '.../cacerts' containing 144 certificates
09:53:48.492 DEBUG --> GET http://127.0.0.1:.../api/v2/analysis/version   (18ms - fast, as expected)
```

...and the identical pattern repeats a moment later in the forked scanner-engine process (another ~2.08s gap around the same "Loaded truststore... 144 certificates" line).

Tracing `sonar-scanner-java-library`:
- `HttpConfig.loadTrustStoreConfig()` unconditionally resolves the JVM's own `cacerts` file as a configured trust store **unless `sonar.scanner.skipJvmSslConfig=true` is set** - a different property from `skipSystemTruststore`.
- `HttpClientFactory.configureSsl()` then reloads that same `cacerts` file a *second time*, through BouncyCastle (`KeyStore.getInstance(type, new BouncyCastleProvider())`) - the ~2.1s operation seen above - on top of the JDK's own fast standard-provider load that `SSLFactory.withDefaultTrustMaterial()` already performs unconditionally, earlier in that same method.

That BouncyCastle reload of the password-protected (`"changeit"`) JVM cacerts is pure duplication for these tests: plain HTTP to a local ephemeral orchestrator-managed server, no client certs presented, no trust need beyond what `withDefaultTrustMaterial()` already provides via the fast path.

## Change

Add `sonar.scanner.skipJvmSslConfig=true` alongside the existing `sonar.scanner.skipSystemTruststore=true` in `BuildRunner.adjustProperties()`.

## Test plan

- Updated `BuildRunnerTest.inject_server_properties` / `inject_properties_for_msbuild_start` to assert the new property is injected.
- `mvn -pl sonar-orchestrator-build test -Dtest=BuildRunnerTest`: 7/7 pass.

## Commits

1. The fix itself.
2. `Prepare next dev iteration` - bumps all 10 `pom.xml` files from `6.4.1-SNAPSHOT` → `6.4.2-SNAPSHOT`, same shape as the ORCH-562 PR, so this can be released as 6.4.2 once merged.
