### PR TITLE
SPE-3255 Upgrade ci-github-actions to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
-      - uses: SonarSource/ci-github-actions/build-maven@v1
+      - uses: SonarSource/ci-github-actions/get-build-number@v2
+      - uses: SonarSource/ci-github-actions/build-maven@v2
         with:
           deploy-pull-request: ${{ github.event_name != 'workflow_call' }}
           artifactory-reader-role: private-reader
@@ -49,7 +49,7 @@ jobs:
         with:
           cache_save: false
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
-      - uses: SonarSource/ci-github-actions/promote@v1
+      - uses: SonarSource/ci-github-actions/get-build-number@v2
+      - uses: SonarSource/ci-github-actions/promote@v2
         with:
           promote-pull-request: true

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.3.13
-      - uses: SonarSource/ci-github-actions/build-maven@v1
+      - uses: SonarSource/ci-github-actions/build-maven@v2
         with:
           artifactory-reader-role: private-reader
           artifactory-deployer-role: qa-deployer


### PR DESCRIPTION
## What

Upgrade all `SonarSource/ci-github-actions/*` references from `@v1` to `@v2`.

`ci-github-actions 2.0.0` fixes a race in `get-build-number`: concurrent runs (e.g. several GitHub Stacked PRs) could be assigned the same build number. Claiming a number now uses an atomic Git-ref compare-and-swap.

## Breaking change

`get-build-number` (and `config-maven`/`config-pip`/`config-uv`, which call it internally) now require `contents: write`. All jobs invoking these actions in this repo already grant `contents: write`, so this PR is version-alignment only — no permission changes needed.

Ref: SPE-3255 · https://discuss.sonarsource.com/t/update-ci-github-actions-2-0-0-atomic-build-number-claiming-fixes-a-real-race-under-github-stacked-prs/24373

### Files
build.yml (get-build-number ×2, build-maven, promote), unified-dogfooding.yml (build-maven).