### PR TITLE
Bump jackson-dataformat-xml to 2.22.2

### DIFF
--- a/sonar-orchestrator-locators/pom.xml
+++ b/sonar-orchestrator-locators/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <version>2.22.1</version>
+      <version>2.22.2</version>
     </dependency>
     <dependency>
       <groupId>com.eclipsesource.minimal-json</groupId>


### PR DESCRIPTION
Bump jackson-dataformat-xml to 2.22.2.

## Details
- Updates the `jackson-dataformat-xml` dependency version in `sonar-orchestrator-locators/pom.xml` from 2.22.1 to 2.22.2.